### PR TITLE
Add KIND benchmark harness

### DIFF
--- a/.github/workflows/bench-kind-smoke.yml
+++ b/.github/workflows/bench-kind-smoke.yml
@@ -1,0 +1,72 @@
+name: Bench / kind smoke
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'bench/kind/**'
+      - '.github/workflows/bench-kind-smoke.yml'
+      - '.github/actions/setup-memagent-build/**'
+  workflow_dispatch:
+    inputs:
+      memagent_ref:
+        description: memagent branch, tag, or SHA to test
+        required: false
+        type: string
+        default: master
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  MEMAGENT_REF: ${{ inputs.memagent_ref || 'master' }}
+
+jobs:
+  kind-bench-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      MEMAGENT_REPO_ROOT: ${{ github.workspace }}/memagent
+      BENCH_RESULTS_DIR: ${{ github.workspace }}/bench/kind/results/smoke
+      CLUSTER_NAME: bench-smoke-${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          repository: strawgate/memagent
+          ref: ${{ env.MEMAGENT_REF }}
+          path: memagent
+      - uses: ./.github/actions/setup-memagent-build
+        with:
+          memagent-repo-root: memagent
+          memagent-ref: ${{ env.MEMAGENT_REF }}
+      - name: Install KIND
+        run: |
+          if ! command -v kind >/dev/null 2>&1; then
+            KIND_VERSION="v0.24.0"
+            curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+            chmod +x ./kind
+            sudo mv ./kind /usr/local/bin/kind
+          fi
+      - name: Run benchmark harness
+        run: |
+          python3 bench/kind/run.py \
+            --phase infra \
+            --profile smoke \
+            --collector logfwd \
+            --protocol otlp_http \
+            --cluster-name "${CLUSTER_NAME}" \
+            --results-dir "${BENCH_RESULTS_DIR}"
+      - if: always()
+        name: Publish summary
+        run: |
+          if [[ -f "${BENCH_RESULTS_DIR}/summary.md" ]]; then
+            cat "${BENCH_RESULTS_DIR}/summary.md" >>"$GITHUB_STEP_SUMMARY"
+          fi
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-bench-smoke
+          path: ${{ env.BENCH_RESULTS_DIR }}
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ crates/logfwd-io/src/dashboard-dist/
 .env
 es-flamegraph.svg
 /tests/e2e/results/
+/bench/kind/results/
 __pycache__/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repo owns:
 - self-contained scenario folders
 - shared artifact/oracle plumbing
 - family-level workflow and phase defaults to keep common cases cheap
+- the KIND competitive benchmark harness under `bench/kind/`
 
 This repo does **not** own the `memagent` product code. Workflows check out
 `strawgate/memagent` as the system under test and build `logfwd:e2e` from that
@@ -23,6 +24,7 @@ image is available.
 
 - `.github/actions/` shared setup and artifact actions
 - `.github/workflows/` one workflow per scenario plus suite callers and reusable family workflows
+- `bench/kind/` benchmark harness, manifests, schema notes, and smoke workflow inputs
 - `tests/e2e/lib/` shared shell and oracle helpers
 - `tests/e2e/scenarios/` one directory per scenario job
 - `docs/SCENARIO_PLATFORM.md` platform rules and scenario contract

--- a/bench/kind/README.md
+++ b/bench/kind/README.md
@@ -1,0 +1,92 @@
+# KIND Competitive Benchmark
+
+This directory contains the single-node KIND benchmark harness for `memagent-e2e`.
+
+The benchmark is intentionally separate from the correctness scenarios under
+`tests/e2e/`. It measures throughput-oriented Kubernetes collection behavior,
+while the scenario suite proves semantic correctness.
+
+## Current Scope
+
+The current implementation covers Phase 0 and Phase 1:
+
+- runtime/tooling decision and default profile selection;
+- deterministic KIND cluster lifecycle;
+- `logfwd` capture sink deployment;
+- canonical run metadata, summary markdown, and artifact collection;
+- smoke CI workflow that exercises the infrastructure path.
+
+It does **not** yet deploy the stdout emitter workload or collector-under-test
+DaemonSets. Those land in later phases on top of this harness.
+
+## Design Choices
+
+- Harness runtime: Python 3, standard library only.
+- Generator and sink direction: `logfwd` is the preferred generator and sink.
+- v1 sink transport: OTLP/HTTP into a `logfwd` sink deployment.
+- Sink persistence: the sink writes JSON lines to stdout and the harness collects
+  pod logs as the benchmark artifact.
+- Benchmark artifacts: JSON row, JSONL stream, summary markdown, rendered
+  manifests, and kubectl debug output.
+
+## Profiles
+
+The harness ships with two named profiles:
+
+- `smoke`
+  - `pods=5`
+  - `eps_per_pod=100`
+  - `warmup=5s`
+  - `measure=15s`
+  - `cooldown=5s`
+- `default`
+  - `pods=30`
+  - `eps_per_pod=300`
+  - `warmup=30s`
+  - `measure=120s`
+  - `cooldown=10s`
+
+For the current `infra` phase, these values are recorded in metadata but not yet
+driven by a workload deployment.
+
+## Prerequisites
+
+- Docker
+- `kind`
+- `kubectl`
+- Python 3
+- a local `logfwd:e2e` image, or a workflow step that builds/tags it first
+
+## Quickstart
+
+```bash
+python3 bench/kind/run.py \
+  --phase infra \
+  --profile smoke \
+  --collector logfwd \
+  --cluster-name memagent-bench-smoke \
+  --memagent-image logfwd:e2e \
+  --results-dir bench/kind/results/local-smoke
+```
+
+Useful flags:
+
+- `--keep-cluster`
+  Leaves the KIND cluster running for inspection.
+- `--namespace`
+  Overrides the benchmark namespace.
+- `--protocol`
+  Records the target sink protocol in metadata. Defaults to `otlp_http`.
+
+## Outputs
+
+Each run writes a directory under `bench/kind/results/` containing:
+
+- `result.json`
+- `results.jsonl`
+- `summary.md`
+- `rendered-manifests/`
+- `artifacts/`
+
+See [RESULT_SCHEMA.md](/Users/billeaston/Documents/repos/memagent-e2e/bench/kind/RESULT_SCHEMA.md)
+for the current row contract.

--- a/bench/kind/RESULT_SCHEMA.md
+++ b/bench/kind/RESULT_SCHEMA.md
@@ -1,0 +1,60 @@
+# KIND Benchmark Result Schema
+
+Each benchmark run emits a canonical row in `results.jsonl` and a matching
+single-object `result.json`.
+
+The contract is designed to be stable across implementation phases. Fields that
+are not collected yet are emitted as `null`.
+
+## Required Fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `benchmark_id` | string | UUID for the run |
+| `timestamp_utc` | string | ISO-8601 UTC timestamp |
+| `phase` | string | `infra` today; later `full` |
+| `cluster` | string | `kind-single-node` |
+| `cluster_name` | string | Actual KIND cluster name |
+| `namespace` | string | Kubernetes namespace used by the run |
+| `collector` | string | Target collector name for the cell |
+| `protocol` | string | Sink protocol, currently `otlp_http` by default |
+| `pods` | integer | Target emitter pod count for the profile |
+| `target_eps_per_pod` | integer | Target rate for the profile |
+| `total_target_eps` | integer | `pods * target_eps_per_pod` |
+| `warmup_sec` | integer | Profile knob |
+| `measure_sec` | integer | Profile knob |
+| `cooldown_sec` | integer | Profile knob |
+| `sink_lines_total` | integer or null | Steady-state delta from sink diagnostics during the measured window |
+| `captured_rows_total` | integer or null | Full count of captured benchmark rows observed in sink artifacts |
+| `sink_lines_per_sec_avg` | number or null | Not yet collected in `infra` |
+| `sink_lines_per_sec_p50` | number or null | Not yet collected in `infra` |
+| `sink_lines_per_sec_p95` | number or null | Not yet collected in `infra` |
+| `sink_lines_per_sec_p99` | number or null | Not yet collected in `infra` |
+| `drop_estimate` | integer or null | Not yet collected in `infra` |
+| `dup_estimate` | integer or null | Not yet collected in `infra` |
+| `latency_ms_p50` | number or null | Not yet collected in `infra` |
+| `latency_ms_p95` | number or null | Not yet collected in `infra` |
+| `latency_ms_p99` | number or null | Not yet collected in `infra` |
+| `collector_cpu_cores_avg` | number or null | Not yet collected in `infra` |
+| `collector_cpu_cores_p95` | number or null | Not yet collected in `infra` |
+| `collector_rss_mb_avg` | number or null | Not yet collected in `infra` |
+| `collector_rss_mb_p95` | number or null | Not yet collected in `infra` |
+| `cluster_ready` | boolean | Whether KIND was created and reachable |
+| `sink_ready` | boolean | Whether the sink deployment became ready |
+| `status` | string | `pass`, `fail`, or `partial` |
+| `notes` | string | Human-readable status note |
+
+## Phase 0 / 1 Behavior
+
+The current implementation always emits the full schema, but only the
+infrastructure status fields are populated. This allows downstream summary code
+to remain stable when throughput and loss metrics are added later.
+
+## Artifact Expectations
+
+Alongside the JSON row, each run should preserve:
+
+- rendered manifests applied to the cluster;
+- `kubectl get all` output;
+- deployment and pod descriptions;
+- sink pod logs when available.

--- a/bench/kind/lib/analyze.py
+++ b/bench/kind/lib/analyze.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def load_json_lines(path: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            rows.append(payload)
+    return rows
+
+
+def benchmark_rows(rows: list[dict[str, object]], benchmark_id: str) -> list[dict[str, object]]:
+    return [row for row in rows if row.get("benchmark_id") == benchmark_id]
+
+
+def expected_emitter_pods(statefulset_name: str, replicas: int) -> list[str]:
+    return [f"{statefulset_name}-{index}" for index in range(replicas)]
+
+
+def summarize_rows(rows: list[dict[str, object]]) -> dict[str, object]:
+    sources = sorted({str(row.get("pod_name")) for row in rows if row.get("pod_name")})
+    event_ids = [str(row.get("event_id")) for row in rows if row.get("event_id")]
+    event_counts = Counter(event_ids)
+    duplicate_count = sum(count - 1 for count in event_counts.values() if count > 1)
+    gap_count = 0
+    by_source: dict[str, list[int]] = {}
+    for row in rows:
+        pod_name = row.get("pod_name")
+        seq = row.get("seq")
+        if isinstance(pod_name, str) and isinstance(seq, int):
+            by_source.setdefault(pod_name, []).append(seq)
+    for seqs in by_source.values():
+        if not seqs:
+            continue
+        ordered = sorted(set(seqs))
+        gap_count += max(0, (ordered[-1] - ordered[0] + 1) - len(ordered))
+    return {
+        "row_count": len(rows),
+        "sources": sources,
+        "duplicate_event_count": duplicate_count,
+        "gap_count": gap_count,
+    }

--- a/bench/kind/lib/cluster.py
+++ b/bench/kind/lib/cluster.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+class CommandError(RuntimeError):
+    pass
+
+
+def require_tool(name: str) -> None:
+    if shutil.which(name) is None:
+        raise CommandError(f"required tool not found on PATH: {name}")
+
+
+def run(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        args,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        capture_output=capture,
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        stdout = (completed.stdout or "").strip()
+        detail = stderr or stdout or f"exit code {completed.returncode}"
+        raise CommandError(f"command failed ({' '.join(args)}): {detail}")
+    return completed
+
+
+def kind_cluster_exists(name: str) -> bool:
+    completed = run(["kind", "get", "clusters"], capture=True)
+    return any(line.strip() == name for line in completed.stdout.splitlines())
+
+
+def create_kind_cluster(name: str, wait: str = "60s") -> None:
+    if kind_cluster_exists(name):
+        return
+    run(["kind", "create", "cluster", "--name", name, "--wait", wait])
+
+
+def delete_kind_cluster(name: str) -> None:
+    if kind_cluster_exists(name):
+        run(["kind", "delete", "cluster", "--name", name])
+
+
+def load_image_into_kind(name: str, image: str) -> None:
+    run(["kind", "load", "docker-image", image, "--name", name])

--- a/bench/kind/lib/kube.py
+++ b/bench/kind/lib/kube.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+from .cluster import CommandError, run
+
+
+def kubectl(
+    args: list[str],
+    *,
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return run(["kubectl", *args], capture=capture)
+
+
+def apply_manifest(path: Path) -> None:
+    kubectl(["apply", "-f", str(path)])
+
+
+def deployment_exists(namespace: str, name: str) -> bool:
+    completed = subprocess.run(
+        ["kubectl", "-n", namespace, "get", "deployment", name],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return completed.returncode == 0
+
+
+def wait_for_deployment(namespace: str, name: str, timeout_sec: int) -> None:
+    kubectl(
+        [
+            "-n",
+            namespace,
+            "wait",
+            f"--timeout={timeout_sec}s",
+            "--for=condition=available",
+            f"deployment/{name}",
+        ]
+    )
+
+
+def rollout_status(namespace: str, kind: str, name: str, timeout_sec: int) -> None:
+    kubectl(
+        [
+            "-n",
+            namespace,
+            "rollout",
+            "status",
+            f"{kind}/{name}",
+            f"--timeout={timeout_sec}s",
+        ]
+    )
+
+
+def get_first_pod_name(namespace: str, selector: str) -> str | None:
+    completed = kubectl(
+        [
+            "-n",
+            namespace,
+            "get",
+            "pods",
+            "-l",
+            selector,
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+        ],
+        capture=True,
+    )
+    pod_name = completed.stdout.strip()
+    return pod_name or None
+
+
+def get_pod_names(namespace: str, selector: str) -> list[str]:
+    completed = kubectl(
+        [
+            "-n",
+            namespace,
+            "get",
+            "pods",
+            "-l",
+            selector,
+            "-o",
+            "jsonpath={range .items[*]}{.metadata.name}{'\\n'}{end}",
+        ],
+        capture=True,
+    )
+    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+
+
+def collect_debug_artifacts(results_dir: Path, namespace: str, deployment: str, selector: str) -> None:
+    artifacts_dir = results_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    commands = {
+        "kubectl-get-all.txt": ["kubectl", "-n", namespace, "get", "all", "-o", "wide"],
+        "kubectl-get-events.txt": ["kubectl", "-n", namespace, "get", "events", "--sort-by=.lastTimestamp"],
+        "kubectl-describe-deployment.txt": ["kubectl", "-n", namespace, "describe", "deployment", deployment],
+        "kubectl-get-pods-json.txt": ["kubectl", "-n", namespace, "get", "pods", "-l", selector, "-o", "json"],
+        "kubectl-get-service.txt": ["kubectl", "-n", namespace, "get", "service", deployment, "-o", "yaml"],
+    }
+
+    for filename, command in commands.items():
+        completed = subprocess.run(command, text=True, capture_output=True, check=False)
+        output = completed.stdout if completed.stdout else completed.stderr
+        (artifacts_dir / filename).write_text(output, encoding="utf-8")
+
+    pod_name = get_first_pod_name(namespace, selector)
+    if pod_name:
+        for suffix, command in {
+            "kubectl-describe-pod.txt": ["kubectl", "-n", namespace, "describe", "pod", pod_name],
+            "sink-logs.txt": ["kubectl", "-n", namespace, "logs", pod_name, "--all-containers=true"],
+        }.items():
+            completed = subprocess.run(command, text=True, capture_output=True, check=False)
+            output = completed.stdout if completed.stdout else completed.stderr
+            (artifacts_dir / suffix).write_text(output, encoding="utf-8")
+
+
+def wait_for_namespace(namespace: str, timeout_sec: int = 15) -> None:
+    deadline = time.time() + timeout_sec
+    while time.time() < deadline:
+        completed = subprocess.run(
+            ["kubectl", "get", "namespace", namespace],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode == 0:
+            return
+        time.sleep(1)
+    raise CommandError(f"namespace did not become visible in time: {namespace}")

--- a/bench/kind/lib/measure.py
+++ b/bench/kind/lib/measure.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import statistics
+import subprocess
+import time
+import urllib.request
+from contextlib import ExitStack
+from dataclasses import dataclass
+
+
+@dataclass
+class StatsSample:
+    timestamp: float
+    output_lines: int
+    rss_bytes: int
+    cpu_total_ms: int
+
+
+class PortForward:
+    def __init__(self, namespace: str, target: str, local_port: int, remote_port: int) -> None:
+        self.namespace = namespace
+        self.target = target
+        self.local_port = local_port
+        self.remote_port = remote_port
+        self.process: subprocess.Popen[str] | None = None
+
+    def __enter__(self) -> "PortForward":
+        self.process = subprocess.Popen(
+            [
+                "kubectl",
+                "-n",
+                self.namespace,
+                "port-forward",
+                self.target,
+                f"{self.local_port}:{self.remote_port}",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            try:
+                fetch_stats(self.local_port)
+                return self
+            except Exception:  # noqa: BLE001
+                time.sleep(0.25)
+        raise RuntimeError(f"port-forward did not become ready: {self.target}")
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.process is not None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5)
+
+
+def fetch_stats(local_port: int) -> dict[str, object]:
+    with urllib.request.urlopen(f"http://127.0.0.1:{local_port}/api/stats", timeout=5) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _sample_from_payload(payload: dict[str, object]) -> StatsSample:
+    cpu_user_ms = int(payload.get("cpu_user_ms", 0) or 0)
+    cpu_sys_ms = int(payload.get("cpu_sys_ms", 0) or 0)
+    return StatsSample(
+        timestamp=time.time(),
+        output_lines=int(payload.get("output_lines", 0) or 0),
+        rss_bytes=int(payload.get("rss_bytes", 0) or 0),
+        cpu_total_ms=cpu_user_ms + cpu_sys_ms,
+    )
+
+
+def collect_logfwd_samples(
+    namespace: str,
+    sink_target: str,
+    collector_target: str,
+    *,
+    warmup_sec: int,
+    measure_sec: int,
+) -> tuple[list[StatsSample], list[StatsSample]]:
+    with ExitStack() as stack:
+        stack.enter_context(PortForward(namespace, sink_target, 19090, 9090))
+        stack.enter_context(PortForward(namespace, collector_target, 19091, 9090))
+
+        if warmup_sec > 0:
+            time.sleep(warmup_sec)
+
+        sink_samples: list[StatsSample] = []
+        collector_samples: list[StatsSample] = []
+        deadline = time.time() + measure_sec
+
+        while True:
+            sink_samples.append(_sample_from_payload(fetch_stats(19090)))
+            collector_samples.append(_sample_from_payload(fetch_stats(19091)))
+            if time.time() >= deadline:
+                break
+            time.sleep(1)
+
+    return sink_samples, collector_samples
+
+
+def diff_output_lines(samples: list[StatsSample]) -> int | None:
+    if len(samples) < 2:
+        return None
+    return max(0, samples[-1].output_lines - samples[0].output_lines)
+
+
+def lines_per_sec_series(samples: list[StatsSample]) -> list[float]:
+    series: list[float] = []
+    for prev, cur in zip(samples, samples[1:]):
+        elapsed = max(cur.timestamp - prev.timestamp, 1e-6)
+        delta = max(0, cur.output_lines - prev.output_lines)
+        series.append(delta / elapsed)
+    return series
+
+
+def cpu_cores_series(samples: list[StatsSample]) -> list[float]:
+    series: list[float] = []
+    for prev, cur in zip(samples, samples[1:]):
+        elapsed = max(cur.timestamp - prev.timestamp, 1e-6)
+        delta_ms = max(0, cur.cpu_total_ms - prev.cpu_total_ms)
+        series.append((delta_ms / 1000.0) / elapsed)
+    return series
+
+
+def rss_mb_series(samples: list[StatsSample]) -> list[float]:
+    return [sample.rss_bytes / (1024.0 * 1024.0) for sample in samples]
+
+
+def percentile(series: list[float], pct: float) -> float | None:
+    if not series:
+        return None
+    if len(series) == 1:
+        return series[0]
+    ordered = sorted(series)
+    rank = (len(ordered) - 1) * pct
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    if lower == upper:
+        return ordered[lower]
+    fraction = rank - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def avg(series: list[float]) -> float | None:
+    if not series:
+        return None
+    return statistics.fmean(series)

--- a/bench/kind/lib/results.py
+++ b/bench/kind/lib/results.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class BenchmarkResult:
+    benchmark_id: str
+    timestamp_utc: str
+    phase: str
+    cluster: str
+    cluster_name: str
+    namespace: str
+    collector: str
+    protocol: str
+    pods: int
+    target_eps_per_pod: int
+    total_target_eps: int
+    warmup_sec: int
+    measure_sec: int
+    cooldown_sec: int
+    sink_lines_total: int | None
+    captured_rows_total: int | None
+    sink_lines_per_sec_avg: float | None
+    sink_lines_per_sec_p50: float | None
+    sink_lines_per_sec_p95: float | None
+    sink_lines_per_sec_p99: float | None
+    drop_estimate: int | None
+    dup_estimate: int | None
+    latency_ms_p50: float | None
+    latency_ms_p95: float | None
+    latency_ms_p99: float | None
+    collector_cpu_cores_avg: float | None
+    collector_cpu_cores_p95: float | None
+    collector_rss_mb_avg: float | None
+    collector_rss_mb_p95: float | None
+    cluster_ready: bool
+    sink_ready: bool
+    status: str
+    notes: str
+
+
+def write_result_files(results_dir: Path, result: BenchmarkResult) -> None:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    payload = asdict(result)
+    (results_dir / "result.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (results_dir / "results.jsonl").write_text(
+        json.dumps(payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (results_dir / "summary.md").write_text(render_summary(result), encoding="utf-8")
+
+
+def render_summary(result: BenchmarkResult) -> str:
+    status = result.status.upper()
+    def show(value: object) -> str:
+        return "n/a" if value is None else str(value)
+
+    lines = [
+        f"# KIND Benchmark / {result.phase}",
+        "",
+        f"- Status: `{status}`",
+        f"- Benchmark ID: `{result.benchmark_id}`",
+        f"- Collector: `{result.collector}`",
+        f"- Protocol: `{result.protocol}`",
+        f"- Cluster: `{result.cluster_name}`",
+        f"- Namespace: `{result.namespace}`",
+        f"- Profile target: `{result.pods}` pods x `{result.target_eps_per_pod}` eps",
+        f"- Cluster ready: `{'yes' if result.cluster_ready else 'no'}`",
+        f"- Sink ready: `{'yes' if result.sink_ready else 'no'}`",
+        f"- Notes: {result.notes}",
+        "",
+        "## Metrics",
+        "",
+        f"- sink_lines_total: `{show(result.sink_lines_total)}`",
+        f"- captured_rows_total: `{show(result.captured_rows_total)}`",
+        f"- sink_lines_per_sec_avg: `{show(result.sink_lines_per_sec_avg)}`",
+        f"- drop_estimate: `{show(result.drop_estimate)}`",
+        f"- dup_estimate: `{show(result.dup_estimate)}`",
+        f"- collector_cpu_cores_avg: `{show(result.collector_cpu_cores_avg)}`",
+        f"- collector_rss_mb_avg: `{show(result.collector_rss_mb_avg)}`",
+    ]
+    return "\n".join(lines).rstrip() + "\n"

--- a/bench/kind/manifests/collectors/logfwd-configmap.yaml.tmpl
+++ b/bench/kind/manifests/collectors/logfwd-configmap.yaml.tmpl
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logfwd-bench-collector-config
+  namespace: ${NAMESPACE}
+data:
+  config.yaml: |
+    server:
+      diagnostics: 0.0.0.0:9090
+      log_level: error
+
+    storage:
+      data_dir: /var/lib/logfwd
+
+    input:
+      type: file
+      path: /var/log/pods/**/*.log
+      format: cri
+
+    transform: |
+      SELECT
+        benchmark_id,
+        pod_name,
+        stream_id,
+        event_id,
+        seq,
+        emit_ts_unix_nano,
+        timestamp,
+        level,
+        message,
+        status,
+        duration_ms,
+        service
+      FROM logs
+      WHERE benchmark_id = '${BENCHMARK_ID}'
+
+    output:
+      type: otlp
+      endpoint: http://logfwd-capture.${NAMESPACE}.svc.cluster.local:4318/v1/logs

--- a/bench/kind/manifests/collectors/logfwd-daemonset.yaml.tmpl
+++ b/bench/kind/manifests/collectors/logfwd-daemonset.yaml.tmpl
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: logfwd-bench-collector
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: logfwd-bench-collector
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: logfwd-bench-collector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: logfwd-bench-collector
+    spec:
+      automountServiceAccountToken: false
+      tolerations:
+        - operator: Exists
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: logfwd
+          image: ${MEMAGENT_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args: ["--config", "/etc/logfwd/config.yaml"]
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: config
+              mountPath: /etc/logfwd
+              readOnly: true
+            - name: state
+              mountPath: /var/lib/logfwd
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+            type: Directory
+        - name: config
+          configMap:
+            name: logfwd-bench-collector-config
+        - name: state
+          emptyDir: {}

--- a/bench/kind/manifests/common/namespace.yaml
+++ b/bench/kind/manifests/common/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: memagent-bench

--- a/bench/kind/manifests/common/sink-configmap.yaml.tmpl
+++ b/bench/kind/manifests/common/sink-configmap.yaml.tmpl
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logfwd-capture-config
+  namespace: ${NAMESPACE}
+data:
+  config.yaml: |
+    server:
+      diagnostics: 0.0.0.0:9090
+    pipelines:
+      capture:
+        inputs:
+          - type: otlp
+            listen: 0.0.0.0:4318
+        outputs:
+          - type: file
+            path: /var/lib/logfwd/capture.ndjson
+            format: json

--- a/bench/kind/manifests/common/sink-deployment.yaml.tmpl
+++ b/bench/kind/manifests/common/sink-deployment.yaml.tmpl
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logfwd-capture
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: logfwd-capture
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: logfwd-capture
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: logfwd-capture
+    spec:
+      containers:
+        - name: logfwd
+          image: ${MEMAGENT_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args: ["--config", "/etc/logfwd/config.yaml"]
+          ports:
+            - name: otlp-http
+              containerPort: 4318
+            - name: diagnostics
+              containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: diagnostics
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          volumeMounts:
+            - name: config
+              mountPath: /etc/logfwd
+              readOnly: true
+            - name: state
+              mountPath: /var/lib/logfwd
+        - name: capture-reader
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "sleep infinity"]
+          volumeMounts:
+            - name: state
+              mountPath: /var/lib/logfwd
+      volumes:
+        - name: config
+          configMap:
+            name: logfwd-capture-config
+        - name: state
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logfwd-capture
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: logfwd-capture
+spec:
+  selector:
+    app.kubernetes.io/name: logfwd-capture
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+    - name: diagnostics
+      port: 9090
+      targetPort: diagnostics

--- a/bench/kind/manifests/workload/log-emitter-configmap.yaml.tmpl
+++ b/bench/kind/manifests/workload/log-emitter-configmap.yaml.tmpl
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: log-emitter-config
+  namespace: ${NAMESPACE}
+data:
+  emit.py: |
+    import json
+    import os
+    import sys
+    import time
+    from datetime import datetime, timezone
+
+    benchmark_id = os.environ["BENCHMARK_ID"]
+    pod_name = os.environ["POD_NAME"]
+    eps = max(int(os.environ.get("EPS_PER_POD", "100")), 1)
+    interval = 1.0 / eps
+    seq = 0
+    levels = ["INFO", "DEBUG", "WARN", "ERROR"]
+
+    while True:
+      seq += 1
+      now = time.time_ns()
+      level = levels[seq % len(levels)]
+      payload = {
+        "benchmark_id": benchmark_id,
+        "pod_name": pod_name,
+        "stream_id": pod_name,
+        "event_id": f"{pod_name}:{seq:08d}",
+        "seq": seq,
+        "emit_ts_unix_nano": now,
+        "timestamp": datetime.fromtimestamp(now / 1_000_000_000, tz=timezone.utc).isoformat(),
+        "level": level,
+        "message": f"bench event {seq}",
+        "status": 500 if level == "ERROR" else 200,
+        "duration_ms": (seq % 250) + 1,
+        "service": "bench-emitter",
+      }
+      sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
+      sys.stdout.flush()
+      time.sleep(interval)

--- a/bench/kind/manifests/workload/log-emitter-statefulset.yaml.tmpl
+++ b/bench/kind/manifests/workload/log-emitter-statefulset.yaml.tmpl
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: log-emitter
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: log-emitter
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: log-emitter
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: log-emitter
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: log-emitter
+spec:
+  serviceName: log-emitter
+  replicas: ${POD_REPLICAS}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: log-emitter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: log-emitter
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: emitter
+          image: python:3.12-alpine
+          imagePullPolicy: IfNotPresent
+          command: ["python", "/opt/emitter/emit.py"]
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BENCHMARK_ID
+              value: "${BENCHMARK_ID}"
+            - name: EPS_PER_POD
+              value: "${EPS_PER_POD}"
+          volumeMounts:
+            - name: config
+              mountPath: /opt/emitter
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: log-emitter-config

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import shutil
+import string
+import sys
+import traceback
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from lib.analyze import benchmark_rows, expected_emitter_pods, load_json_lines, summarize_rows
+from lib.cluster import CommandError, create_kind_cluster, delete_kind_cluster, load_image_into_kind, require_tool
+from lib.kube import (
+    apply_manifest,
+    collect_debug_artifacts,
+    get_first_pod_name,
+    get_pod_names,
+    rollout_status,
+    wait_for_deployment,
+    wait_for_namespace,
+)
+from lib.measure import (
+    avg,
+    collect_logfwd_samples,
+    cpu_cores_series,
+    diff_output_lines,
+    lines_per_sec_series,
+    percentile,
+    rss_mb_series,
+)
+from lib.results import BenchmarkResult, write_result_files
+
+
+BENCH_ROOT = Path(__file__).resolve().parent
+COMMON_MANIFESTS_ROOT = BENCH_ROOT / "manifests" / "common"
+COLLECTOR_MANIFESTS_ROOT = BENCH_ROOT / "manifests" / "collectors"
+WORKLOAD_MANIFESTS_ROOT = BENCH_ROOT / "manifests" / "workload"
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    pods: int
+    eps_per_pod: int
+    warmup_sec: int
+    measure_sec: int
+    cooldown_sec: int
+
+
+PROFILES = {
+    "smoke": Profile("smoke", pods=5, eps_per_pod=100, warmup_sec=5, measure_sec=15, cooldown_sec=5),
+    "default": Profile("default", pods=30, eps_per_pod=300, warmup_sec=30, measure_sec=120, cooldown_sec=10),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the KIND competitive benchmark harness.")
+    parser.add_argument("--phase", choices=["infra", "smoke"], default="smoke")
+    parser.add_argument("--profile", choices=sorted(PROFILES), default="smoke")
+    parser.add_argument("--collector", default="logfwd")
+    parser.add_argument("--protocol", default="otlp_http")
+    parser.add_argument("--cluster-name", default="memagent-bench")
+    parser.add_argument("--namespace", default="memagent-bench")
+    parser.add_argument("--memagent-image", default="logfwd:e2e")
+    parser.add_argument("--results-dir", default=None)
+    parser.add_argument("--keep-cluster", action="store_true")
+    return parser.parse_args()
+
+
+def resolve_results_dir(raw: str | None) -> Path:
+    if raw:
+        return Path(raw).resolve()
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return (BENCH_ROOT / "results" / timestamp).resolve()
+
+
+def render_template(template_name: str, destination: Path, substitutions: dict[str, str]) -> None:
+    if template_name.startswith("collectors/"):
+        template_path = COLLECTOR_MANIFESTS_ROOT / template_name.removeprefix("collectors/")
+    elif template_name.startswith("workload/"):
+        template_path = WORKLOAD_MANIFESTS_ROOT / template_name.removeprefix("workload/")
+    else:
+        template_path = COMMON_MANIFESTS_ROOT / template_name
+    content = string.Template(template_path.read_text(encoding="utf-8")).safe_substitute(substitutions)
+    destination.write_text(content, encoding="utf-8")
+
+
+def copy_static_manifest(filename: str, destination: Path, substitutions: dict[str, str]) -> None:
+    source = COMMON_MANIFESTS_ROOT / filename
+    content = string.Template(source.read_text(encoding="utf-8")).safe_substitute(substitutions)
+    destination.write_text(content, encoding="utf-8")
+
+
+def ensure_tools() -> None:
+    for tool in ("curl", "docker", "kind", "kubectl", "python3"):
+        require_tool(tool)
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    profile = PROFILES[args.profile]
+    results_dir = resolve_results_dir(args.results_dir)
+    rendered_dir = results_dir / "rendered-manifests"
+    rendered_dir.mkdir(parents=True, exist_ok=True)
+
+    benchmark_id = str(uuid.uuid4())
+    timestamp_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    total_target_eps = profile.pods * profile.eps_per_pod
+
+    result = BenchmarkResult(
+        benchmark_id=benchmark_id,
+        timestamp_utc=timestamp_utc,
+        phase=args.phase,
+        cluster="kind-single-node",
+        cluster_name=args.cluster_name,
+        namespace=args.namespace,
+        collector=args.collector,
+        protocol=args.protocol,
+        pods=profile.pods,
+        target_eps_per_pod=profile.eps_per_pod,
+        total_target_eps=total_target_eps,
+        warmup_sec=profile.warmup_sec,
+        measure_sec=profile.measure_sec,
+        cooldown_sec=profile.cooldown_sec,
+        sink_lines_total=None,
+        captured_rows_total=None,
+        sink_lines_per_sec_avg=None,
+        sink_lines_per_sec_p50=None,
+        sink_lines_per_sec_p95=None,
+        sink_lines_per_sec_p99=None,
+        drop_estimate=None,
+        dup_estimate=None,
+        latency_ms_p50=None,
+        latency_ms_p95=None,
+        latency_ms_p99=None,
+        collector_cpu_cores_avg=None,
+        collector_cpu_cores_p95=None,
+        collector_rss_mb_avg=None,
+        collector_rss_mb_p95=None,
+        cluster_ready=False,
+        sink_ready=False,
+        status="partial",
+        notes="run started",
+    )
+
+    namespace_manifest = rendered_dir / "namespace.yaml"
+    sink_configmap_manifest = rendered_dir / "sink-configmap.yaml"
+    sink_deployment_manifest = rendered_dir / "sink-deployment.yaml"
+    collector_configmap_manifest = rendered_dir / "collector-configmap.yaml"
+    collector_daemonset_manifest = rendered_dir / "collector-daemonset.yaml"
+    emitter_configmap_manifest = rendered_dir / "emitter-configmap.yaml"
+    emitter_statefulset_manifest = rendered_dir / "emitter-statefulset.yaml"
+    substitutions = {
+        "NAMESPACE": args.namespace,
+        "MEMAGENT_IMAGE": args.memagent_image,
+        "BENCHMARK_ID": benchmark_id,
+        "EPS_PER_POD": str(profile.eps_per_pod),
+        "POD_REPLICAS": str(profile.pods),
+    }
+
+    try:
+        ensure_tools()
+        copy_static_manifest("namespace.yaml", namespace_manifest, substitutions)
+        render_template("sink-configmap.yaml.tmpl", sink_configmap_manifest, substitutions)
+        render_template("sink-deployment.yaml.tmpl", sink_deployment_manifest, substitutions)
+        if args.phase == "smoke":
+            if args.collector != "logfwd":
+                raise CommandError(f"collector not implemented yet in benchmark harness: {args.collector}")
+            render_template("collectors/logfwd-configmap.yaml.tmpl", collector_configmap_manifest, substitutions)
+            render_template("collectors/logfwd-daemonset.yaml.tmpl", collector_daemonset_manifest, substitutions)
+            render_template("workload/log-emitter-configmap.yaml.tmpl", emitter_configmap_manifest, substitutions)
+            render_template("workload/log-emitter-statefulset.yaml.tmpl", emitter_statefulset_manifest, substitutions)
+
+        create_kind_cluster(args.cluster_name)
+        result.cluster_ready = True
+        load_image_into_kind(args.cluster_name, args.memagent_image)
+
+        apply_manifest(namespace_manifest)
+        wait_for_namespace(args.namespace)
+        apply_manifest(sink_configmap_manifest)
+        apply_manifest(sink_deployment_manifest)
+        wait_for_deployment(args.namespace, "logfwd-capture", timeout_sec=90)
+
+        result.sink_ready = True
+
+        if args.phase == "infra":
+            result.status = "pass"
+            result.notes = (
+                "infra-only benchmark run succeeded; cluster lifecycle and logfwd sink deployment are healthy. "
+                "Workload generation and collector-under-test installation land in later phases."
+            )
+        else:
+            apply_manifest(emitter_configmap_manifest)
+            apply_manifest(emitter_statefulset_manifest)
+            rollout_status(args.namespace, "statefulset", "log-emitter", timeout_sec=120)
+
+            apply_manifest(collector_configmap_manifest)
+            apply_manifest(collector_daemonset_manifest)
+            rollout_status(args.namespace, "daemonset", "logfwd-bench-collector", timeout_sec=120)
+
+            collector_pod = get_first_pod_name(args.namespace, "app.kubernetes.io/name=logfwd-bench-collector")
+            if not collector_pod:
+                raise CommandError("collector pod not found after rollout")
+
+            sink_samples, collector_samples = collect_logfwd_samples(
+                args.namespace,
+                "deployment/logfwd-capture",
+                f"pod/{collector_pod}",
+                warmup_sec=profile.warmup_sec,
+                measure_sec=profile.measure_sec,
+            )
+
+            result.sink_lines_total = diff_output_lines(sink_samples)
+            sink_series = lines_per_sec_series(sink_samples)
+            result.sink_lines_per_sec_avg = avg(sink_series)
+            result.sink_lines_per_sec_p50 = percentile(sink_series, 0.50)
+            result.sink_lines_per_sec_p95 = percentile(sink_series, 0.95)
+            result.sink_lines_per_sec_p99 = percentile(sink_series, 0.99)
+
+            cpu_series = cpu_cores_series(collector_samples)
+            rss_series = rss_mb_series(collector_samples)
+            result.collector_cpu_cores_avg = avg(cpu_series)
+            result.collector_cpu_cores_p95 = percentile(cpu_series, 0.95)
+            result.collector_rss_mb_avg = avg(rss_series)
+            result.collector_rss_mb_p95 = percentile(rss_series, 0.95)
+
+            sink_pod = get_first_pod_name(args.namespace, "app.kubernetes.io/name=logfwd-capture")
+            if not sink_pod:
+                raise CommandError("sink pod not found after rollout")
+
+            artifacts_dir = results_dir / "artifacts"
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
+            sink_logs_path = artifacts_dir / "sink-logs.txt"
+            sink_logs = subprocess.run(
+                ["kubectl", "-n", args.namespace, "logs", sink_pod, "--tail=-1"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            sink_logs_path.write_text(
+                sink_logs.stdout if sink_logs.stdout else sink_logs.stderr,
+                encoding="utf-8",
+            )
+
+            sink_capture_path = artifacts_dir / "sink-capture.ndjson"
+            sink_capture = subprocess.run(
+                [
+                    "kubectl",
+                    "-n",
+                    args.namespace,
+                    "exec",
+                    "-c",
+                    "capture-reader",
+                    sink_pod,
+                    "--",
+                    "cat",
+                    "/var/lib/logfwd/capture.ndjson",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            sink_capture_path.write_text(
+                sink_capture.stdout if sink_capture.stdout else sink_capture.stderr,
+                encoding="utf-8",
+            )
+
+            rows = benchmark_rows(load_json_lines(sink_capture_path), benchmark_id)
+            summary = summarize_rows(rows)
+            expected_sources = expected_emitter_pods("log-emitter", profile.pods)
+            missing_sources = sorted(set(expected_sources) - set(summary["sources"]))
+            result.captured_rows_total = int(summary["row_count"])
+
+            write_json(results_dir / "actual_rows.json", rows)
+            write_json(
+                results_dir / "stream-summary.json",
+                {
+                    "expected_sources": expected_sources,
+                    "observed_sources": summary["sources"],
+                    "missing_sources": missing_sources,
+                    "duplicate_event_count": summary["duplicate_event_count"],
+                    "gap_count": summary["gap_count"],
+                    "row_count": summary["row_count"],
+                },
+            )
+
+            result.dup_estimate = int(summary["duplicate_event_count"])
+            result.drop_estimate = int(summary["gap_count"])
+
+            if (
+                result.sink_lines_total
+                and not missing_sources
+                and summary["gap_count"] == 0
+                and summary["duplicate_event_count"] == 0
+            ):
+                result.status = "pass"
+                result.notes = (
+                    f"smoke benchmark succeeded; captured_rows_total={summary['row_count']}, "
+                    f"sink_lines_total={result.sink_lines_total}; observed "
+                    f"{len(summary['sources'])}/{profile.pods} emitter pods with "
+                    f"{summary['gap_count']} gaps and {summary['duplicate_event_count']} duplicate events."
+                )
+                return_code = 0
+            else:
+                result.status = "fail"
+                result.notes = (
+                    f"smoke benchmark failed; sink_lines_total={result.sink_lines_total}, "
+                    f"captured_rows_total={summary['row_count']}, "
+                    f"missing_sources={missing_sources}, gaps={summary['gap_count']}, "
+                    f"duplicates={summary['duplicate_event_count']}"
+                )
+                return_code = 1
+        if args.phase == "infra":
+            return_code = 0
+    except Exception as exc:  # noqa: BLE001
+        result.status = "fail"
+        result.notes = f"{type(exc).__name__}: {exc}"
+        (results_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+        (results_dir / "artifacts" / "traceback.txt").write_text(traceback.format_exc(), encoding="utf-8")
+        return_code = 1
+    finally:
+        try:
+            collect_debug_artifacts(
+                results_dir,
+                namespace=args.namespace,
+                deployment="logfwd-capture",
+                selector="app.kubernetes.io/name=logfwd-capture",
+            )
+            emitter_logs_path = results_dir / "artifacts" / "emitter-logs.txt"
+            emitter_pods = get_pod_names(args.namespace, "app.kubernetes.io/name=log-emitter")
+            if emitter_pods:
+                chunks: list[str] = []
+                for pod_name in emitter_pods:
+                    chunks.append(f"==== {pod_name}")
+                    proc = subprocess.run(
+                        ["kubectl", "-n", args.namespace, "logs", pod_name, "--tail=100"],
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    chunks.append(proc.stdout if proc.stdout else proc.stderr)
+                emitter_logs_path.write_text("\n".join(chunks), encoding="utf-8")
+            collector_pods = get_pod_names(args.namespace, "app.kubernetes.io/name=logfwd-bench-collector")
+            if collector_pods:
+                chunks = []
+                for pod_name in collector_pods:
+                    chunks.append(f"==== {pod_name}")
+                    proc = subprocess.run(
+                        ["kubectl", "-n", args.namespace, "logs", pod_name, "--tail=200"],
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    chunks.append(proc.stdout if proc.stdout else proc.stderr)
+                (results_dir / "artifacts" / "collector-logs.txt").write_text("\n".join(chunks), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            artifacts_dir = results_dir / "artifacts"
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
+            (artifacts_dir / "artifact-collection-error.txt").write_text(str(exc), encoding="utf-8")
+
+        if not args.keep_cluster:
+            try:
+                delete_kind_cluster(args.cluster_name)
+            except Exception as exc:  # noqa: BLE001
+                artifacts_dir = results_dir / "artifacts"
+                artifacts_dir.mkdir(parents=True, exist_ok=True)
+                (artifacts_dir / "cluster-delete-error.txt").write_text(str(exc), encoding="utf-8")
+
+        write_result_files(results_dir, result)
+
+    print(results_dir)
+    return return_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a new  harness for the single-node KIND competitive benchmark
- deploy a  sink, parameterized emitter workload, and  collector-under-test with canonical result artifacts
- add a smoke workflow plus docs/schema notes for local and CI usage

## Validation
- 
- local KIND smoke benchmark passed twice with all 5 emitter pods observed and 0 gaps / 0 duplicate events
