### PR TITLE
Fix smoke suite memagent ref fallback to main

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -62,7 +62,7 @@ jobs:
   otlp-output-oracle:
     uses: ./.github/workflows/e2e-otlp-output-oracle.yml
     with:
-      memagent_ref: ${{ inputs.memagent_ref || 'master' }}
+      memagent_ref: ${{ inputs.memagent_ref || 'main' }}
     secrets: inherit
 
   summarize:


### PR DESCRIPTION
## Summary
- change `otlp-output-oracle` in `e2e-smoke.yml` to use `main` fallback instead of `master`
- keeps PR-triggered smoke jobs aligned with the rest of the suite when `workflow_dispatch` inputs are absent

## Why
- `inputs.memagent_ref` is undefined on `pull_request` events
- previous fallback could silently route this one smoke job to `master` while other jobs use `main`

## Validation
- `actionlint .github/workflows/e2e-smoke.yml`
