### PR TITLE
Harden bench workflow against vector and stash race failures

### DIFF
--- a/.github/workflows/bench-kind-smoke.yml
+++ b/.github/workflows/bench-kind-smoke.yml
@@ -116,7 +116,7 @@ jobs:
             sudo mv ./kind /usr/local/bin/kind
           fi
       - name: Run benchmark harness
-        continue-on-error: ${{ github.event_name == 'pull_request' && matrix.collector == 'vector' }}
+        continue-on-error: ${{ matrix.collector == 'vector' }}
         run: |
           python3 bench/kind/run.py \
             --phase smoke \
@@ -131,14 +131,21 @@ jobs:
             --results-dir "${BENCH_RESULTS_DIR}"
       - if: env.PERSIST_BENCH_DATA == 'true'
         name: Stash benchmark run
+        continue-on-error: true
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         uses: strawgate/octo11y/actions/stash@main-dist
         with:
           results: ${{ env.BENCH_RESULTS_DIR }}/benchkit-run.otlp.json
           format: otlp
           run-id: ${{ env.BENCHKIT_RUN_ID }}
           summary: true
-      - if: env.PERSIST_BENCH_DATA == 'true'
+      - if: env.PERSIST_BENCH_DATA == 'true' && matrix.collector == 'logfwd' && matrix.cpu_profile == 'single'
         name: Trigger aggregate
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run bench-kind-aggregate.yml --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
- allow vector benchmark matrix jobs to fail without failing the entire workflow
- make bench-data stash and aggregate trigger non-blocking to avoid known branch race flakiness
- set explicit git author/committer env vars for stash commits

## Why
This keeps nightly and manual benchmark runs producing usable artifacts/results even when vector runs or bench-data persistence has transient contention.

## Validation
- Dispatched bench-kind-smoke from this branch; workflow completed successfully with expected warning-only stash contention.