### PR TITLE
Fix memcached nightly failure by ensuring log mount write access

### DIFF
--- a/tests/e2e/scenarios/compose-memcached/compose.yaml
+++ b/tests/e2e/scenarios/compose-memcached/compose.yaml
@@ -13,6 +13,7 @@ services:
 
   memcached:
     image: memcached:1.6-alpine
+    user: "0:0"
     command:
       - sh
       - -lc


### PR DESCRIPTION
## What failed
- Nightly run https://github.com/strawgate/memagent-e2e/actions/runs/24067672370 failed early due to `memagent_ref=master` checkout in an older workflow revision.
- After rerunning nightly from current `master`, checkout regression was resolved, but `compose-memcached` failed:
  - `tee: /logs/memcached.log: Permission denied`
  - `source_evidence.py` then crashed with missing `logs/memcached.log`.

## Fix
- In `tests/e2e/scenarios/compose-memcached/compose.yaml`, run the `memcached` service as root (`user: "0:0"`) so `/logs/memcached.log` is writable in CI.

## Validation
- `E2E / compose-memcached` on this branch passed: https://github.com/strawgate/memagent-e2e/actions/runs/24083053069
- Full `E2E / nightly suite` on this branch passed: https://github.com/strawgate/memagent-e2e/actions/runs/24083092679
