### PR TITLE
Fix bench aggregate duplicate auth header failures

### DIFF
--- a/.github/workflows/bench-kind-aggregate.yml
+++ b/.github/workflows/bench-kind-aggregate.yml
@@ -17,6 +17,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Aggregate benchmark data
         uses: strawgate/octo11y/actions/aggregate@main-dist
         with:


### PR DESCRIPTION
## Problem
`Bench / kind aggregate` repeatedly failed with:
- `remote: Duplicate header: "Authorization"`
- `Failed to fetch 'bench-data' from origin`

Root cause: `actions/checkout` persisted credentials in local git config, and the Octo11y aggregate action also set an auth header.

## Fix
- Set `persist-credentials: false` on checkout in `.github/workflows/bench-kind-aggregate.yml`.

## Validation
- Reproduced failure signature in prior runs (`24071901151`, `24071313012`).
- Dispatched aggregate on this branch and confirmed success:
  - https://github.com/strawgate/memagent-e2e/actions/runs/24083908278
