### PR TITLE
Bench: add sink CPU/RSS diagnostics to KIND benchmark results

### DIFF
--- a/bench/kind/RESULT_SCHEMA.md
+++ b/bench/kind/RESULT_SCHEMA.md
@@ -45,6 +45,10 @@ land. Fields that are not collected in a phase are emitted as `null`.
 | `latency_ms_p50` | number or null | Reserved for later latency capture |
 | `latency_ms_p95` | number or null | Reserved for later latency capture |
 | `latency_ms_p99` | number or null | Reserved for later latency capture |
+| `sink_cpu_cores_avg` | number or null | Average sink CPU usage during the measured window |
+| `sink_cpu_cores_p95` | number or null | P95 sink CPU usage during the measured window |
+| `sink_rss_mb_avg` | number or null | Average sink RSS during the measured window |
+| `sink_rss_mb_p95` | number or null | P95 sink RSS during the measured window |
 | `collector_cpu_cores_avg` | number or null | Average collector CPU usage during the measured window |
 | `collector_cpu_cores_p95` | number or null | P95 collector CPU usage during the measured window |
 | `collector_rss_mb_avg` | number or null | Average collector RSS during the measured window |
@@ -65,7 +69,7 @@ All source-vs-sink and steady-state throughput fields remain `null`.
 
 The smoke phase currently runs one narrow benchmark mode:
 
-- collectors: `logfwd`, `otelcol`
+- collectors: `logfwd`, `otelcol`, `vector`
 - mode: `baseline-pass-through`
 - oracle: compare benchmark-tagged sink rows against the emitter logs captured
   from the source pods

--- a/bench/kind/lib/results.py
+++ b/bench/kind/lib/results.py
@@ -43,6 +43,10 @@ class BenchmarkResult:
     latency_ms_p50: float | None
     latency_ms_p95: float | None
     latency_ms_p99: float | None
+    sink_cpu_cores_avg: float | None
+    sink_cpu_cores_p95: float | None
+    sink_rss_mb_avg: float | None
+    sink_rss_mb_p95: float | None
     collector_cpu_cores_avg: float | None
     collector_cpu_cores_p95: float | None
     collector_rss_mb_avg: float | None
@@ -115,6 +119,10 @@ def _metric_specs(result: BenchmarkResult) -> list[tuple[str, float | int | None
         ("latency_ms_p50", result.latency_ms_p50, "ms", "smaller_is_better", "outcome"),
         ("latency_ms_p95", result.latency_ms_p95, "ms", "smaller_is_better", "outcome"),
         ("latency_ms_p99", result.latency_ms_p99, "ms", "smaller_is_better", "outcome"),
+        ("sink_cpu_cores_avg", result.sink_cpu_cores_avg, "cores", "smaller_is_better", "diagnostic"),
+        ("sink_cpu_cores_p95", result.sink_cpu_cores_p95, "cores", "smaller_is_better", "diagnostic"),
+        ("sink_rss_mb_avg", result.sink_rss_mb_avg, "MB", "smaller_is_better", "diagnostic"),
+        ("sink_rss_mb_p95", result.sink_rss_mb_p95, "MB", "smaller_is_better", "diagnostic"),
         ("collector_cpu_cores_avg", result.collector_cpu_cores_avg, "cores", "smaller_is_better", "diagnostic"),
         ("collector_cpu_cores_p95", result.collector_cpu_cores_p95, "cores", "smaller_is_better", "diagnostic"),
         ("collector_rss_mb_avg", result.collector_rss_mb_avg, "MB", "smaller_is_better", "diagnostic"),
@@ -409,6 +417,8 @@ def render_summary(result: BenchmarkResult) -> str:
         f"- sink_lines_per_sec_avg: `{show(result.sink_lines_per_sec_avg)}`",
         f"- drop_estimate: `{show(result.drop_estimate)}`",
         f"- dup_estimate: `{show(result.dup_estimate)}`",
+        f"- sink_cpu_cores_avg: `{show(result.sink_cpu_cores_avg)}`",
+        f"- sink_rss_mb_avg: `{show(result.sink_rss_mb_avg)}`",
         f"- collector_cpu_cores_avg: `{show(result.collector_cpu_cores_avg)}`",
         f"- collector_rss_mb_avg: `{show(result.collector_rss_mb_avg)}`",
     ]

--- a/bench/kind/render_issue_summary.py
+++ b/bench/kind/render_issue_summary.py
@@ -25,6 +25,7 @@ class BenchResult:
     unexpected_event_count: int | None
     dup_estimate: int | None
     drop_estimate: int | None
+    sink_cpu_cores_avg: float | None
     collector_cpu_cores_avg: float | None
     notes: str
 
@@ -91,6 +92,7 @@ def load_result(path: Path, artifact_name: str) -> BenchResult:
         unexpected_event_count=as_int(payload.get("unexpected_event_count")),
         dup_estimate=as_int(payload.get("dup_estimate")),
         drop_estimate=as_int(payload.get("drop_estimate")),
+        sink_cpu_cores_avg=as_float(payload.get("sink_cpu_cores_avg")),
         collector_cpu_cores_avg=as_float(payload.get("collector_cpu_cores_avg")),
         notes=str(payload.get("notes") or ""),
     )
@@ -264,8 +266,8 @@ def render_markdown(
                     [
                         f"### Ingest: `{ingest_mode}`",
                         "",
-                        "| Collector | Target EPS | Status | EPS Avg | Collector CPU Avg | % of Target | Missing | Unexpected | Duplicates | Dropped |",
-                        "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+                        "| Collector | Target EPS | Status | EPS Avg | Collector CPU Avg | Sink CPU Avg | % of Target | Missing | Unexpected | Duplicates | Dropped |",
+                        "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
                     ]
                 )
                 for result in sorted(
@@ -280,12 +282,13 @@ def render_markdown(
                     if result.sink_lines_per_sec_avg is not None and result.total_target_eps > 0:
                         eps_ratio = result.sink_lines_per_sec_avg / result.total_target_eps
                     lines.append(
-                        "| {collector} | {target_eps} | {status} | {eps_avg} | {cpu_avg} | {ratio} | {missing} | {unexpected} | {dup} | {drop} |".format(
+                        "| {collector} | {target_eps} | {status} | {eps_avg} | {collector_cpu_avg} | {sink_cpu_avg} | {ratio} | {missing} | {unexpected} | {dup} | {drop} |".format(
                             collector=result.collector,
                             target_eps="max" if result.total_target_eps == 0 else fmt_int(result.total_target_eps),
                             status=result.status.upper(),
                             eps_avg=fmt_float(result.sink_lines_per_sec_avg),
-                            cpu_avg=fmt_float(result.collector_cpu_cores_avg),
+                            collector_cpu_avg=fmt_float(result.collector_cpu_cores_avg),
+                            sink_cpu_avg=fmt_float(result.sink_cpu_cores_avg),
                             ratio=fmt_percent(eps_ratio),
                             missing=fmt_int(result.missing_event_count),
                             unexpected=fmt_int(result.unexpected_event_count),
@@ -348,6 +351,7 @@ def main() -> None:
                 "unexpected_event_count": result.unexpected_event_count,
                 "dup_estimate": result.dup_estimate,
                 "drop_estimate": result.drop_estimate,
+                "sink_cpu_cores_avg": result.sink_cpu_cores_avg,
                 "collector_cpu_cores_avg": result.collector_cpu_cores_avg,
                 "notes": result.notes,
             }

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -598,6 +598,13 @@ def run_smoke_phase(
     result.sink_lines_per_sec_p95 = percentile(sink_series, 0.95)
     result.sink_lines_per_sec_p99 = percentile(sink_series, 0.99)
 
+    sink_cpu_series = cpu_cores_series(sink_samples)
+    sink_rss_series = rss_mb_series(sink_samples)
+    result.sink_cpu_cores_avg = avg(sink_cpu_series)
+    result.sink_cpu_cores_p95 = percentile(sink_cpu_series, 0.95)
+    result.sink_rss_mb_avg = avg(sink_rss_series)
+    result.sink_rss_mb_p95 = percentile(sink_rss_series, 0.95)
+
     cpu_series = cpu_cores_series(collector_samples)
     rss_series = rss_mb_series(collector_samples)
     result.collector_cpu_cores_avg = avg(cpu_series)
@@ -945,6 +952,10 @@ def main() -> int:
         latency_ms_p50=None,
         latency_ms_p95=None,
         latency_ms_p99=None,
+        sink_cpu_cores_avg=None,
+        sink_cpu_cores_p95=None,
+        sink_rss_mb_avg=None,
+        sink_rss_mb_p95=None,
         collector_cpu_cores_avg=None,
         collector_cpu_cores_p95=None,
         collector_rss_mb_avg=None,


### PR DESCRIPTION
## Summary
- add sink-side CPU and RSS diagnostics to the canonical KIND benchmark result row
- propagate those metrics into Benchkit OTLP projection and benchmark markdown summaries
- include sink CPU average in nightly EPS report tables so bottlenecks are easier to spot
- update RESULT_SCHEMA docs to include the new sink diagnostics and align collector list with current support

## Validation
- python3 -m py_compile bench/kind/run.py bench/kind/render_issue_summary.py bench/kind/lib/results.py bench/kind/lib/measure.py
- rendered bench/kind/render_issue_summary.py with empty and sample artifact sets to verify output formatting

## Why
We already capture sink samples; this makes the sink resource signal first-class in reports so we can distinguish collector saturation from sink-side pressure during throughput investigations.