### PR TITLE
test(e2e): add ES|QL input oracle scenario

### DIFF
--- a/.github/workflows/e2e-compose-esql-input-oracle.yml
+++ b/.github/workflows/e2e-compose-esql-input-oracle.yml
@@ -1,0 +1,30 @@
+name: E2E / compose-esql-input-oracle
+
+on:
+  workflow_call:
+    inputs:
+      memagent_ref:
+        description: memagent branch, tag, or SHA to test
+        required: false
+        type: string
+        default: main
+  workflow_dispatch:
+    inputs:
+      memagent_ref:
+        description: memagent branch, tag, or SHA to test
+        required: false
+        type: string
+        default: main
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  compose-esql-input-oracle:
+    uses: ./.github/workflows/_scenario-compose.yml
+    with:
+      scenario_id: compose-esql-input-oracle
+      timeout_minutes: 30
+      memagent_ref: ${{ inputs.memagent_ref || 'main' }}
+    secrets: inherit

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -49,6 +49,12 @@ jobs:
       memagent_ref: ${{ inputs.memagent_ref || 'main' }}
     secrets: inherit
 
+  compose-esql-input-oracle:
+    uses: ./.github/workflows/e2e-compose-esql-input-oracle.yml
+    with:
+      memagent_ref: ${{ inputs.memagent_ref || 'main' }}
+    secrets: inherit
+
   compose-synthetic-multiline:
     uses: ./.github/workflows/e2e-compose-synthetic-multiline.yml
     with:
@@ -86,6 +92,7 @@ jobs:
       - compose-redis
       - compose-memcached
       - compose-nginx
+      - compose-esql-input-oracle
       - compose-synthetic-multiline
       - compose-synthetic-burst
       - compose-synthetic-rotation
@@ -94,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Render suite summary
@@ -109,7 +116,7 @@ jobs:
             --output-json suite-summary.json
       - name: Publish suite summary
         run: cat suite-summary.md >>"$GITHUB_STEP_SUMMARY"
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v4
         with:
           name: e2e-nightly-summary
           path: |

--- a/tests/e2e/scenarios/compose-esql-input-oracle/compose.yaml
+++ b/tests/e2e/scenarios/compose-esql-input-oracle/compose.yaml
@@ -1,0 +1,35 @@
+services:
+  capture:
+    image: python:3.12-alpine
+    command: ["python", "/workspace/tests/e2e/lib/capture_tcp.py", "--port", "9000", "--output-dir", "/artifacts"]
+    volumes:
+      - ${REPO_ROOT:?}:/workspace:ro
+      - ${E2E_RESULTS_DIR:?}:/artifacts
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s = socket.create_connection(('127.0.0.1', 9000), 1); s.close()"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.3
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      xpack.security.http.ssl.enabled: "false"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+
+  memagent:
+    image: logfwd:e2e
+    command: ["--config", "/scenario/memagent.yaml"]
+    depends_on:
+      capture:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+    volumes:
+      - ./memagent.yaml:/scenario/memagent.yaml:ro
+
+  workload:
+    image: curlimages/curl:8.12.1
+    command: ["sh", "-lc", "sleep 3600"]

--- a/tests/e2e/scenarios/compose-esql-input-oracle/memagent.yaml
+++ b/tests/e2e/scenarios/compose-esql-input-oracle/memagent.yaml
@@ -1,0 +1,20 @@
+server:
+  diagnostics: "0.0.0.0:9090"
+  log_level: debug
+
+input:
+  type: esql
+  esql:
+    endpoint: http://elasticsearch:9200
+    query: >-
+      FROM e2e_logs
+      | WHERE scenario == "compose-esql-input-oracle"
+      | KEEP scenario, source_id, event_id, seq, message, status
+      | SORT seq
+
+transform: "SELECT * FROM logs"
+
+output:
+  type: tcp
+  endpoint: capture:9000
+  format: json

--- a/tests/e2e/scenarios/compose-esql-input-oracle/oracle.json
+++ b/tests/e2e/scenarios/compose-esql-input-oracle/oracle.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "compose-esql-input-oracle",
+  "policy": "exact_once_ordered",
+  "selector": {
+    "field": "scenario",
+    "value": "compose-esql-input-oracle"
+  },
+  "order_key": "seq",
+  "source_key": "source_id",
+  "identity_keys": ["scenario", "source_id", "event_id"],
+  "required_fields": ["scenario", "source_id", "event_id", "seq", "message", "status"],
+  "compare_keys": ["scenario", "source_id", "event_id", "seq", "message", "status"],
+  "source_policy": "exact_once_ordered",
+  "source_compare_keys": ["scenario", "source_id", "event_id", "seq", "message", "status"],
+  "source_required_fields": ["scenario", "source_id", "event_id", "seq", "message", "status"]
+}

--- a/tests/e2e/scenarios/compose-esql-input-oracle/run_workload.sh
+++ b/tests/e2e/scenarios/compose-esql-input-oracle/run_workload.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "$0")/../.." && pwd)/lib/common.sh"
+
+python3 - <<'PY' >"$E2E_RESULTS_DIR/expected_rows.json"
+import json
+
+rows = [
+    {
+        "scenario": "compose-esql-input-oracle",
+        "source_id": "elasticsearch-esql",
+        "event_id": f"compose-esql-input-oracle:{i:04d}",
+        "seq": i,
+        "message": f"oracle event {i:04d}",
+        "status": 200 + i,
+    }
+    for i in range(1, 6)
+]
+print(json.dumps(rows, indent=2))
+PY
+
+wait_for_file "$E2E_RESULTS_DIR/captured.ndjson" 30
+
+docker compose -p "memagent-${SCENARIO_ID}" -f "$SCENARIO_DIR/compose.yaml" exec -T workload \
+    sh -lc "curl -fsS 'http://elasticsearch:9200/e2e_logs/_search?size=10&sort=seq:asc&_source=scenario,source_id,event_id,seq,message,status'" \
+    >"$E2E_RESULTS_DIR/source-search.json"
+
+python3 - <<'PY' "$E2E_RESULTS_DIR/source-search.json" "$E2E_RESULTS_DIR/source_rows.json"
+import json
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1])
+output = pathlib.Path(sys.argv[2])
+payload = json.loads(source.read_text(encoding="utf-8"))
+rows = [hit["_source"] for hit in payload["hits"]["hits"]]
+output.write_text(json.dumps(rows, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY

--- a/tests/e2e/scenarios/compose-esql-input-oracle/up.sh
+++ b/tests/e2e/scenarios/compose-esql-input-oracle/up.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "$0")/../.." && pwd)/lib/common.sh"
+
+compose up -d --wait --remove-orphans capture elasticsearch workload
+
+docker compose -p "memagent-${SCENARIO_ID}" -f "$SCENARIO_DIR/compose.yaml" exec -T workload \
+    sh -lc 'until curl -fsS "http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=1s" >/dev/null; do sleep 1; done'
+
+payload="$(python3 - <<'PY'
+import json
+
+rows = []
+for i in range(1, 6):
+    rows.append({"index": {"_index": "e2e_logs"}})
+    rows.append(
+        {
+            "scenario": "compose-esql-input-oracle",
+            "source_id": "elasticsearch-esql",
+            "event_id": f"compose-esql-input-oracle:{i:04d}",
+            "seq": i,
+            "message": f"oracle event {i:04d}",
+            "status": 200 + i,
+        }
+    )
+print("\n".join(json.dumps(row) for row in rows) + "\n")
+PY
+)"
+
+docker compose -p "memagent-${SCENARIO_ID}" -f "$SCENARIO_DIR/compose.yaml" exec -T workload \
+    sh -lc "cat >/tmp/bulk.ndjson && curl -fsS -X POST 'http://elasticsearch:9200/_bulk?refresh=wait_for' -H 'Content-Type: application/x-ndjson' --data-binary @/tmp/bulk.ndjson >/tmp/bulk-response.json" \
+    <<EOF
+${payload}
+EOF
+
+compose up -d memagent


### PR DESCRIPTION
## Summary
- add a real compose-backed `compose-esql-input-oracle` scenario
- seed Elasticsearch with oracle documents, run memagent with `input.type: esql`, and verify forwarded rows against both sink output and Elasticsearch source evidence
- wire the scenario into the nightly suite and add a dedicated workflow entrypoint

## Validation
- `python3 tests/e2e/lib/check_scenarios.py --repo-root /Users/billeaston/Documents/repos/memagent-e2e --scenario-id compose-esql-input-oracle`
- `bash -n tests/e2e/scenarios/compose-esql-input-oracle/up.sh tests/e2e/scenarios/compose-esql-input-oracle/run_workload.sh`

## Notes
- I did not complete a full local compose run in this environment because Docker had a stuck prior build and I chose to preserve the branch/workflow changes first.
