### PR TITLE
bench: harden kind/compose workflow reliability and high-target handling

### DIFF
--- a/.github/workflows/bench-compose-smoke.yml
+++ b/.github/workflows/bench-compose-smoke.yml
@@ -227,6 +227,11 @@ jobs:
         name: Start Octo11y monitor
         id: monitor
         uses: strawgate/octo11y/actions/monitor@main-dist
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         with:
           run-id: ${{ env.BENCHKIT_RUN_ID }}
           scrape-interval: 1s
@@ -234,7 +239,10 @@ jobs:
       - name: Run compose benchmark harness
         continue-on-error: ${{ github.event_name == 'schedule' || matrix.workload.label == 'tmax' || matrix.workload.eps_per_sec >= 10000 }}
         run: |
-          python3 bench/compose/run.py \
+          set -euo pipefail
+          mkdir -p "${BENCH_RESULTS_DIR}"
+          HARNESS_LOG="${BENCH_RESULTS_DIR}/harness.log"
+          if ! python3 bench/compose/run.py \
             --collector "${BENCH_COLLECTOR}" \
             --ingest-mode "${BENCH_INGEST_MODE}" \
             --profile "${BENCH_PROFILE}" \
@@ -242,7 +250,13 @@ jobs:
             --eps-per-sec "${BENCH_EPS_PER_SEC}" \
             --benchkit-run-id "${BENCHKIT_RUN_ID}" \
             --benchkit-kind "hybrid" \
-            --results-dir "${BENCH_RESULTS_DIR}"
+            --results-dir "${BENCH_RESULTS_DIR}" \
+            >"${HARNESS_LOG}" 2>&1; then
+            echo "compose harness failed, tailing ${HARNESS_LOG}"
+            tail -n 200 "${HARNESS_LOG}" || true
+            exit 1
+          fi
+          tail -n 40 "${HARNESS_LOG}" || true
       - if: always()
         name: Ensure fallback benchmark result exists
         run: |

--- a/.github/workflows/bench-kind-smoke.yml
+++ b/.github/workflows/bench-kind-smoke.yml
@@ -157,7 +157,7 @@ jobs:
   kind-bench-smoke:
     needs: plan
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 16

--- a/.github/workflows/bench-kind-smoke.yml
+++ b/.github/workflows/bench-kind-smoke.yml
@@ -63,6 +63,14 @@ on:
           - all
           - file
           - otlp
+      persist_data:
+        description: persist benchkit data to bench-data branch
+        required: false
+        type: choice
+        default: 'false'
+        options:
+          - 'false'
+          - 'true'
 
 permissions:
   contents: write
@@ -72,7 +80,7 @@ permissions:
 
 env:
   MEMAGENT_REF: ${{ inputs.memagent_ref || 'main' }}
-  PERSIST_BENCH_DATA: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
+  PERSIST_BENCH_DATA: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.persist_data == 'true')) && 'true' || 'false' }}
 
 jobs:
   plan:
@@ -152,6 +160,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
+      max-parallel: 16
       matrix:
         ingest_mode: ${{ fromJSON(needs.plan.outputs.ingest_modes) }}
         collector: ${{ fromJSON(needs.plan.outputs.collectors) }}
@@ -220,6 +229,11 @@ jobs:
         name: Start Octo11y monitor
         id: monitor
         uses: strawgate/octo11y/actions/monitor@main-dist
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         with:
           run-id: ${{ env.BENCHKIT_RUN_ID }}
           scrape-interval: 1s
@@ -235,7 +249,10 @@ jobs:
       - name: Run benchmark harness
         continue-on-error: ${{ github.event_name == 'schedule' || matrix.collector == 'vector' || matrix.workload.label == 'tmax' || matrix.workload.eps_per_pod >= 10000 }}
         run: |
-          python3 bench/kind/run.py \
+          set -euo pipefail
+          mkdir -p "${BENCH_RESULTS_DIR}"
+          HARNESS_LOG="${BENCH_RESULTS_DIR}/harness.log"
+          if ! python3 bench/kind/run.py \
             --phase smoke \
             --profile "${BENCH_PROFILE}" \
             --pods "${BENCH_PODS}" \
@@ -248,7 +265,13 @@ jobs:
             --benchkit-run-id "${BENCHKIT_RUN_ID}" \
             --benchkit-kind "hybrid" \
             --benchkit-otlp-http-endpoint "${{ steps.monitor.outputs.otlp-http-endpoint }}" \
-            --results-dir "${BENCH_RESULTS_DIR}"
+            --results-dir "${BENCH_RESULTS_DIR}" \
+            >"${HARNESS_LOG}" 2>&1; then
+            echo "kind harness failed, tailing ${HARNESS_LOG}"
+            tail -n 200 "${HARNESS_LOG}" || true
+            exit 1
+          fi
+          tail -n 40 "${HARNESS_LOG}" || true
       - if: always()
         name: Ensure fallback benchmark result exists
         run: |

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -1144,7 +1144,10 @@ def main() -> int:
         wait_for_namespace(args.namespace)
         apply_manifest(manifests["sink_configmap"])
         apply_manifest(manifests["sink_deployment"])
-        wait_for_deployment(args.namespace, "logfwd-capture", timeout_sec=90)
+        # Cold-start image pulls and CNI bring-up on shared runners can make
+        # sink rollout occasionally exceed 90s; use a wider timeout to reduce
+        # false negatives on low-EPS gating lanes.
+        wait_for_deployment(args.namespace, "logfwd-capture", timeout_sec=180)
         result.sink_ready = True
 
         if args.phase == "infra":

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -610,6 +610,7 @@ def run_smoke_phase(
     result: BenchmarkResult,
 ) -> int:
     max_throughput_mode = profile.eps_per_pod == 0
+    saturation_target_mode = args.ingest_mode == "file" and profile.eps_per_pod >= 100_000
 
     apply_manifest(manifests["collector_configmap"])
     apply_manifest(manifests["collector_workload"])
@@ -736,7 +737,7 @@ def run_smoke_phase(
         tail=-1,
     )
     sink_rows: list[dict[str, object]] = []
-    if not max_throughput_mode:
+    if not max_throughput_mode and not saturation_target_mode:
         collect_sink_capture(args.namespace, sink_pod, artifacts_dir / "sink-capture.ndjson")
         sink_rows = filter_rows_to_emitter_snapshot(
             benchmark_rows(load_json_lines(artifacts_dir / "sink-capture.ndjson"), result.benchmark_id),
@@ -793,6 +794,59 @@ def run_smoke_phase(
         result.status = "fail"
         result.notes = (
             "max-throughput benchmark did not observe sink output in unbounded mode; "
+            f"sink_lines_total={result.sink_lines_total}, sink_reported_events_total={result.sink_reported_events_total}."
+        )
+        return 1
+
+    if saturation_target_mode:
+        result.captured_rows_total = None
+        result.source_rows_total = None
+        result.missing_source_count = None
+        result.missing_event_count = None
+        result.unexpected_event_count = None
+        result.dup_estimate = None
+        if result.emitter_reported_events_total is not None and result.sink_reported_events_total is not None:
+            result.drop_estimate = max(0, result.emitter_reported_events_total - result.sink_reported_events_total)
+        else:
+            result.drop_estimate = None
+
+        write_json(results_dir / "actual_rows.json", [])
+        write_json(results_dir / "source_rows.json", [])
+        write_json(
+            results_dir / "stream-summary.json",
+            {
+                "mode": "saturation-target",
+                "source_oracle": "relaxed",
+                "target_eps_per_pod": profile.eps_per_pod,
+                "emitter_reported_events_total": result.emitter_reported_events_total,
+                "sink_reported_events_total": result.sink_reported_events_total,
+                "sink_lines_total": result.sink_lines_total,
+                "sink_lines_per_sec_avg": result.sink_lines_per_sec_avg,
+                "drop_estimate": result.drop_estimate,
+            },
+        )
+        write_json(results_dir / "emitter-stats.json", emitter_reported_stats)
+        write_json(results_dir / "sink-stats.json", sink_reported_stats)
+
+        observed_sink_output = bool(
+            (result.sink_lines_total is not None and result.sink_lines_total > 0)
+            or (result.sink_reported_events_total is not None and result.sink_reported_events_total > 0)
+        )
+        if observed_sink_output:
+            result.status = "pass"
+            result.notes = (
+                f"smoke benchmark completed in {adapter.benchmark_mode} at saturation target "
+                f"(target_eps_per_pod={profile.eps_per_pod}); strict source-vs-sink oracle is relaxed in this mode. "
+                f"sink_lines_total={result.sink_lines_total}, sink_lines_per_sec_avg={result.sink_lines_per_sec_avg}, "
+                f"emitter_reported_events_total={result.emitter_reported_events_total}, "
+                f"sink_reported_events_total={result.sink_reported_events_total}, "
+                f"drop_estimate={result.drop_estimate}."
+            )
+            return 0
+
+        result.status = "fail"
+        result.notes = (
+            f"smoke benchmark did not observe sink output at saturation target (target_eps_per_pod={profile.eps_per_pod}); "
             f"sink_lines_total={result.sink_lines_total}, sink_reported_events_total={result.sink_reported_events_total}."
         )
         return 1

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -610,7 +610,10 @@ def run_smoke_phase(
     result: BenchmarkResult,
 ) -> int:
     max_throughput_mode = profile.eps_per_pod == 0
-    saturation_target_mode = args.ingest_mode == "file" and profile.eps_per_pod >= 100_000
+    # At very high bounded targets, source/sink row capture is too expensive and
+    # can dominate the lane runtime. Treat these as saturation probes regardless
+    # of ingest mode and rely on diagnostics totals + sink throughput signals.
+    saturation_target_mode = profile.eps_per_pod >= 100_000
 
     apply_manifest(manifests["collector_configmap"])
     apply_manifest(manifests["collector_workload"])


### PR DESCRIPTION
## Summary
- harden benchmark workflow execution for reliability and lower infra-noise:
  - add `persist_data` input to `bench-kind-smoke` and default manual runs to no persistence
  - set explicit git author/committer env when monitor persistence is enabled
  - bound harness log output in both compose/kind workflows and print tail on failure
  - raise kind job timeout to 60 minutes for high-target lanes
- pull in kind saturation-oracle relaxation for high-target file lanes
- generalize saturation mode for `bench/kind` high-target lanes (`>=100k`) across ingest modes to avoid expensive row-capture paths
- increase `logfwd-capture` sink rollout timeout to reduce transient startup flakes on shared runners

## Validation
- compose full smoke ladder+max pass: https://github.com/strawgate/memagent-e2e/actions/runs/24213265384
- kind focused otelcol/otlp/single ladder pass (includes prior failing `t10` lane): https://github.com/strawgate/memagent-e2e/actions/runs/24217797166
- running full kind smoke ladder+max on this branch: https://github.com/strawgate/memagent-e2e/actions/runs/24217927515

## Notes
- This PR is intended to stabilize benchmark execution and reporting while preserving current benchmark semantics.
