### PR TITLE
bench(kind): harden diagnostics polling + capture settle

### DIFF
--- a/bench/kind/README.md
+++ b/bench/kind/README.md
@@ -47,8 +47,8 @@ scores yet.
   shaping the benchmark envelope in SQL before writing to stdout.
 - Sink: `logfwd` configured as a dumb capture sink writing JSON lines to a file.
 - Producer counters:
-  - emitters expose `logfwd` diagnostics via `/api/stats`
-  - the sink exposes `logfwd` diagnostics via `/api/stats`
+  - emitters expose `logfwd` diagnostics via `/admin/v1/stats` (with legacy `/api/stats` fallback)
+  - the sink exposes `logfwd` diagnostics via `/admin/v1/stats` (with legacy `/api/stats` fallback)
 - Benchmark artifacts: JSON row, JSONL stream, summary markdown, rendered
   manifests, and `kubectl` debug output.
 - Reporting integration: `benchkit-run.otlp.json` for Octo11y

--- a/bench/kind/RESULT_SCHEMA.md
+++ b/bench/kind/RESULT_SCHEMA.md
@@ -29,8 +29,8 @@ land. Fields that are not collected in a phase are emitted as `null`.
 | `measure_sec` | integer | Profile knob |
 | `cooldown_sec` | integer | Profile knob |
 | `sink_lines_total` | integer or null | Steady-state delta from sink diagnostics during the measured window |
-| `emitter_reported_events_total` | integer or null | Sum of emitter-side reported totals collected from each emitter pod's `logfwd` `/api/stats` diagnostics |
-| `sink_reported_events_total` | integer or null | Sink-side reported total collected from the sink `logfwd` `/api/stats` diagnostics |
+| `emitter_reported_events_total` | integer or null | Sum of emitter-side reported totals collected from each emitter pod's `logfwd` `/admin/v1/stats` diagnostics (legacy `/api/stats` fallback) |
+| `sink_reported_events_total` | integer or null | Sink-side reported total collected from the sink `logfwd` `/admin/v1/stats` diagnostics (legacy `/api/stats` fallback) |
 | `captured_rows_total` | integer or null | Full count of captured benchmark rows observed in sink artifacts |
 | `source_rows_total` | integer or null | Full count of benchmark rows observed in emitter artifacts |
 | `missing_source_count` | integer or null | Expected emitter pods absent from sink artifacts |

--- a/bench/kind/lib/measure.py
+++ b/bench/kind/lib/measure.py
@@ -130,8 +130,102 @@ def _fetch_json_with_retries(
     raise RuntimeError(f"failed to fetch JSON from {path}: {last_exc}") from last_exc
 
 
+def _fetch_json_from_paths(
+    local_port: int,
+    paths: list[str],
+    *,
+    timeout_sec: int = 5,
+    attempts: int = 4,
+) -> tuple[dict[str, object], str]:
+    last_exc: Exception | None = None
+    for path in paths:
+        try:
+            payload = _fetch_json_with_retries(
+                local_port,
+                path,
+                timeout_sec=timeout_sec,
+                attempts=attempts,
+            )
+            return payload, path
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+    if last_exc is None:
+        raise RuntimeError("failed to fetch JSON from any candidate path")
+    raise RuntimeError(f"failed to fetch JSON from candidate paths {paths}: {last_exc}") from last_exc
+
+
+def _as_int(value: object, default: int = 0) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return default
+        try:
+            if "." in text:
+                return int(float(text))
+            return int(text)
+        except ValueError:
+            return default
+    return default
+
+
+def _normalize_status_payload(payload: dict[str, object]) -> dict[str, object]:
+    pipelines = payload.get("pipelines", [])
+    input_lines = 0
+    output_lines = 0
+    if isinstance(pipelines, list):
+        for pipeline in pipelines:
+            if not isinstance(pipeline, dict):
+                continue
+            transform = pipeline.get("transform")
+            if isinstance(transform, dict):
+                input_lines += _as_int(transform.get("lines_in"), 0)
+                output_lines += _as_int(transform.get("lines_out"), 0)
+
+    system = payload.get("system")
+    memory = system.get("memory") if isinstance(system, dict) else None
+    rss_bytes = _as_int(memory.get("resident"), 0) if isinstance(memory, dict) else 0
+
+    return {
+        "input_lines": input_lines,
+        "output_lines": output_lines,
+        "rss_bytes": rss_bytes,
+        "cpu_user_ms": 0,
+        "cpu_sys_ms": 0,
+    }
+
+
+def _normalize_stats_payload(payload: dict[str, object]) -> dict[str, object]:
+    if "input_lines" in payload or "output_lines" in payload:
+        return {
+            "input_lines": _as_int(payload.get("input_lines"), 0),
+            "output_lines": _as_int(payload.get("output_lines"), 0),
+            "rss_bytes": _as_int(payload.get("rss_bytes"), 0),
+            "cpu_user_ms": _as_int(payload.get("cpu_user_ms"), 0),
+            "cpu_sys_ms": _as_int(payload.get("cpu_sys_ms"), 0),
+        }
+    if "pipelines" in payload:
+        return _normalize_status_payload(payload)
+    return {
+        "input_lines": 0,
+        "output_lines": 0,
+        "rss_bytes": 0,
+        "cpu_user_ms": 0,
+        "cpu_sys_ms": 0,
+    }
+
+
 def fetch_stats(local_port: int) -> dict[str, object]:
-    return _fetch_json_with_retries(local_port, "/api/stats")
+    payload, _ = _fetch_json_from_paths(
+        local_port,
+        ["/admin/v1/stats", "/api/stats", "/admin/v1/status"],
+    )
+    return _normalize_stats_payload(payload)
 
 
 def fetch_capture_stats(local_port: int) -> dict[str, object]:

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -539,6 +539,56 @@ def wait_for_sink_catch_up(
         time.sleep(poll_sec)
 
 
+def wait_for_capture_reader_stability(
+    *,
+    namespace: str,
+    sink_pod: str,
+    sink_stats_port: int,
+    initial_stats: dict[str, object],
+    timeout_sec: float = 3.0,
+    poll_sec: float = 0.25,
+    required_stable_polls: int = 2,
+) -> dict[str, object]:
+    deadline = time.time() + timeout_sec
+    last_stats = initial_stats
+    last_total = int(initial_stats.get("benchmark_rows_total", 0) or 0)
+    last_max_by_pod = initial_stats.get("benchmark_max_seq_by_pod")
+    if not isinstance(last_max_by_pod, dict):
+        last_max_by_pod = {}
+    stable_polls = 0
+
+    while time.time() < deadline:
+        try:
+            current = collect_sink_reported_stats(
+                namespace,
+                sink_pod,
+                sink_stats_kind="capture_reader",
+                sink_stats_port=sink_stats_port,
+            )
+        except Exception:  # noqa: BLE001
+            time.sleep(poll_sec)
+            continue
+
+        current_total = int(current.get("benchmark_rows_total", 0) or 0)
+        current_max_by_pod = current.get("benchmark_max_seq_by_pod")
+        if not isinstance(current_max_by_pod, dict):
+            current_max_by_pod = {}
+
+        if current_total == last_total and current_max_by_pod == last_max_by_pod:
+            stable_polls += 1
+            if stable_polls >= required_stable_polls:
+                return current
+        else:
+            stable_polls = 0
+            last_total = current_total
+            last_max_by_pod = current_max_by_pod
+
+        last_stats = current
+        time.sleep(poll_sec)
+
+    return last_stats
+
+
 def render_manifests(
     *,
     args: argparse.Namespace,
@@ -729,6 +779,16 @@ def run_smoke_phase(
         emitter_reported_stats=emitter_reported_stats,
         timeout_sec=drain_timeout_sec,
     )
+    if sink_stats_kind == "capture_reader":
+        # capture-reader stats can lead file writes by a short interval.
+        # Wait for a couple of stable polls before reading capture.ndjson so
+        # strict source-vs-sink checks do not fail on last-line races.
+        sink_reported_stats = wait_for_capture_reader_stability(
+            namespace=args.namespace,
+            sink_pod=sink_pod,
+            sink_stats_port=sink_stats_port,
+            initial_stats=sink_reported_stats,
+        )
     result.sink_reported_events_total = sink_reported_events_total(
         sink_reported_stats,
         sink_stats_kind=sink_stats_kind,


### PR DESCRIPTION
## Summary
- switch benchmark diagnostics polling to prefer `/admin/v1/stats` with legacy `/api/stats` and `/admin/v1/status` fallback normalization
- add a short capture-reader stability wait after sink catch-up to reduce strict-oracle last-line races before reading `capture.ndjson`
- update kind benchmark docs/schema to reflect `/admin/v1/stats` diagnostics source

## Why
- memagent removed legacy `/api/stats`; polling only that path can break benchmark metrics collection
- current master run `24229630276` showed a strict-oracle flake (`file/logfwd/multi/t1k`) with a single missing event despite sink diagnostics parity, consistent with capture flush timing races

## Validation
- `python3 -m py_compile bench/kind/lib/measure.py bench/kind/run.py`
- local normalization sanity check for flat and status payloads
