### PR TITLE
ci(bench): isolate live report threads by target set

### DIFF
--- a/.github/workflows/bench-compose-smoke.yml
+++ b/.github/workflows/bench-compose-smoke.yml
@@ -430,9 +430,10 @@ jobs:
               echo "labels=live-suite-report,report:bench,report:bench-compose,report:bench-compose-nightly-eps"
             } >>"$GITHUB_OUTPUT"
           else
+            target_set="${{ needs.plan.outputs.target_set }}"
             {
-              echo "title_base=Bench Compose Competitive Benchmarks Report"
-              echo "suite_key=bench-compose-competitive"
+              echo "title_base=Bench Compose Competitive Benchmarks Report (${target_set})"
+              echo "suite_key=bench-compose-competitive-${target_set}"
               echo "labels=live-suite-report,report:bench,report:bench-compose,report:bench-compose-competitive"
             } >>"$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/bench-kind-smoke.yml
+++ b/.github/workflows/bench-kind-smoke.yml
@@ -420,9 +420,10 @@ jobs:
               echo "labels=live-suite-report,report:bench,report:bench-nightly-eps"
             } >>"$GITHUB_OUTPUT"
           else
+            target_set="${{ needs.plan.outputs.target_set }}"
             {
-              echo "title_base=Bench Competitive Benchmarks Report"
-              echo "suite_key=bench-competitive"
+              echo "title_base=Bench Competitive Benchmarks Report (${target_set})"
+              echo "suite_key=bench-competitive-${target_set}"
               echo "labels=live-suite-report,report:bench,report:bench-competitive"
             } >>"$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary
- make kind benchmark live report `suite_key` include `target_set` for non-scheduled runs
- make compose benchmark live report `suite_key` include `target_set` for non-scheduled runs
- include `target_set` in non-scheduled report title text for quick context

## Why
- small targeted dispatches were overwriting the same competitive report issue used by full matrix runs
- this makes the benchmark dashboard misleading (for example a 7-lane verification run replacing full competitive status)

## Result
- `profile`, `ladder`, `ladder_and_max`, and `max` runs now keep separate issue threads for competitive reports
- scheduled nightly report keys remain unchanged
