### PR TITLE
bench(kind): prevent otelcol tmax OTLP startup OOM

### DIFF
--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -299,6 +299,21 @@ def build_resource_plan(
     )
 
 
+def adjust_resource_plan_for_adapter(
+    *,
+    resource_plan: ResourcePlan,
+    adapter: CollectorAdapter,
+    ingest_mode: str,
+    profile: Profile,
+) -> ResourcePlan:
+    # OTel collector can OOM in unbounded OTLP mode before readiness settles.
+    # Give max-throughput OTLP lanes more headroom so the lane reports throughput
+    # instead of failing during startup.
+    if adapter.name == "otelcol" and ingest_mode == "otlp" and profile.eps_per_pod == 0:
+        return replace(resource_plan, collector_memory="2Gi")
+    return resource_plan
+
+
 def resolve_profile(
     *,
     profile_name: str,
@@ -1118,6 +1133,12 @@ def main() -> int:
         emitter_pods=profile.pods,
         eps_per_pod=profile.eps_per_pod,
         unbounded_generator=profile.eps_per_pod == 0,
+    )
+    resource_plan = adjust_resource_plan_for_adapter(
+        resource_plan=resource_plan,
+        adapter=adapter,
+        ingest_mode=args.ingest_mode,
+        profile=profile,
     )
     results_dir = resolve_results_dir(args.results_dir)
     rendered_dir = results_dir / "rendered-manifests"


### PR DESCRIPTION
## Summary
- add adapter-specific resource adjustment for kind benchmarks
- when collector is `otelcol` in `otlp` ingest with unbounded generator (`tmax`), raise collector memory limit/request to `2Gi`

## Why
- full master kind run `24229989603` was green-but-noisy with 2 non-gating failures in:
  - `otlp/tmax/single/otelcol`
  - `otlp/tmax/multi/otelcol`
- both lanes failed before measurement because otelcol was OOMKilled during startup, which kept emitter readiness at 503 and timed out rollout

## Validation
- `python3 -m py_compile bench/kind/run.py`
- artifact audit confirms prior failure mode was collector OOMKilled + emitter readiness timeout
