### PR TITLE
bench(kind): smooth low-EPS ladders by scaling generator batch

### DIFF
--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -613,7 +613,12 @@ def render_manifests(
     benchmark_id: str,
     rendered_dir: Path,
 ) -> dict[str, Path]:
-    generator_batch_size = 64 if profile.eps_per_pod == 0 else 1024
+    if profile.eps_per_pod == 0:
+        generator_batch_size = 64
+    else:
+        # Keep low-rate targets smooth so per-second throughput sampling reflects
+        # the requested EPS instead of front-loading a large first burst.
+        generator_batch_size = max(1, min(1024, profile.eps_per_pod))
     substitutions = {
         "NAMESPACE": args.namespace,
         "MEMAGENT_IMAGE": args.memagent_image,


### PR DESCRIPTION
## Summary
- scale kind emitter generator batch size by target EPS for bounded workloads
- keep `tmax` behavior unchanged (`batch_size=64`)
- avoid front-loaded bursts that flatten low-EPS measurement windows

## Why
Kind low-target lanes (`t1`, `t10`) could complete most events before the measure window, reporting `0.00` EPS despite successful delivery. This aligns kind behavior with compose and improves benchmark signal quality.

## Validation
- `python3 -m py_compile bench/kind/run.py`
- dispatched focused kind ladder run on this branch (`file`, `logfwd`, `single`)
