### PR TITLE
bench(kind): tolerate transient diagnostics sample drops

### DIFF
--- a/bench/kind/lib/measure.py
+++ b/bench/kind/lib/measure.py
@@ -424,7 +424,12 @@ def collect_bench_samples(
                         cpu_total_ms=prev.cpu_total_ms,
                     )
                 else:
-                    raise
+                    sink_sample = StatsSample(
+                        timestamp=time.time(),
+                        output_lines=0,
+                        rss_bytes=0,
+                        cpu_total_ms=0,
+                    )
             sink_samples.append(sink_sample)
 
             try:
@@ -439,7 +444,12 @@ def collect_bench_samples(
                         cpu_total_ms=prev.cpu_total_ms,
                     )
                 else:
-                    raise
+                    collector_sample = StatsSample(
+                        timestamp=time.time(),
+                        output_lines=0,
+                        rss_bytes=0,
+                        cpu_total_ms=0,
+                    )
             collector_samples.append(collector_sample)
             if time.time() >= deadline:
                 break


### PR DESCRIPTION
## Summary
- avoid hard-failing kind benchmark lanes when sink/collector diagnostics sampling drops before the first sample
- on a transient first-sample failure, record a zero sample and continue sampling
- preserve existing behavior of carrying forward the previous sample once any sample exists

## Why
Post-fix full run `24245004450` still had two flaky failures in `otelcol/otlp/tmax` caused by diagnostics port-forward disconnects (`RemoteDisconnected`, connection reset), not a deterministic pipeline regression. This keeps benchmark lanes robust to transient diagnostics channel instability.

## Validation
- `python3 -m py_compile bench/kind/lib/measure.py bench/kind/run.py`
- dispatch focused kind max run on this branch (`collector=otelcol`, `ingest=otlp`, `cpu=all`)
