### PR TITLE
bench(kind): increase shared OTLP max collector memory to 4Gi

### DIFF
--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -309,7 +309,7 @@ def adjust_resource_plan_for_adapter(
     # Keep lane resources identical across collectors. For max-throughput OTLP
     # runs, use a common collector memory envelope to reduce restart noise.
     if ingest_mode == "otlp" and profile.eps_per_pod == 0:
-        return replace(resource_plan, collector_memory="3Gi")
+        return replace(resource_plan, collector_memory="4Gi")
     return resource_plan
 
 

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -309,7 +309,7 @@ def adjust_resource_plan_for_adapter(
     # Keep lane resources identical across collectors. For max-throughput OTLP
     # runs, use a common collector memory envelope to reduce restart noise.
     if ingest_mode == "otlp" and profile.eps_per_pod == 0:
-        return replace(resource_plan, collector_memory="4Gi")
+        return replace(resource_plan, collector_memory="6Gi")
     return resource_plan
 
 

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -309,7 +309,7 @@ def adjust_resource_plan_for_adapter(
     # Keep lane resources identical across collectors. For max-throughput OTLP
     # runs, use a common collector memory envelope to reduce restart noise.
     if ingest_mode == "otlp" and profile.eps_per_pod == 0:
-        return replace(resource_plan, collector_memory="6Gi")
+        return replace(resource_plan, collector_memory="8Gi")
     return resource_plan
 
 


### PR DESCRIPTION
## Summary
- increase max-throughput OTLP collector memory from `3Gi` to `8Gi` for all collectors

## Why
Post-merge validation of #181 showed `otelcol/otlp/max` still OOM-restarting at `3Gi`, then still unstable at `4Gi` and `6Gi` in targeted validation.

This change keeps resource fairness intact by applying the same memory envelope to every collector for OTLP max lanes.

## Validation
- `python3 -m py_compile bench/kind/run.py`
- targeted runs executed for:
  - `target_set=max`
  - `collector=otelcol`
  - `ingest_mode=otlp`
  - `cpu_profile=all`
