### PR TITLE
bench/e2e: stabilize nightly main and fill compose sink CPU

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -49,12 +49,6 @@ jobs:
       memagent_ref: ${{ inputs.memagent_ref || 'main' }}
     secrets: inherit
 
-  compose-esql-input-oracle:
-    uses: ./.github/workflows/e2e-compose-esql-input-oracle.yml
-    with:
-      memagent_ref: ${{ inputs.memagent_ref || 'main' }}
-    secrets: inherit
-
   compose-synthetic-multiline:
     uses: ./.github/workflows/e2e-compose-synthetic-multiline.yml
     with:
@@ -92,7 +86,6 @@ jobs:
       - compose-redis
       - compose-memcached
       - compose-nginx
-      - compose-esql-input-oracle
       - compose-synthetic-multiline
       - compose-synthetic-burst
       - compose-synthetic-rotation

--- a/bench/compose/run.py
+++ b/bench/compose/run.py
@@ -1091,6 +1091,8 @@ def main() -> int:
     )
 
     sink_samples: list[StatsSample] = []
+    sink_cpu_samples: list[float] = []
+    sink_rss_samples: list[float] = []
     collector_cpu_samples: list[float] = []
     collector_rss_samples: list[float] = []
     collector_resource_samples: list[dict[str, float]] = []
@@ -1108,6 +1110,7 @@ def main() -> int:
         wait_until_ready(lambda: fetch_stats(sink_diag_port), timeout_sec=90)
         result.cluster_ready = True
         result.sink_ready = True
+        sink_container_id = resolve_container_id(compose, "sink", env)
 
         wait_for_collector_ready(adapter, collector_stats_port, timeout_sec=90)
         collector_container_id = resolve_container_id(compose, adapter.service_name, env)
@@ -1141,6 +1144,12 @@ def main() -> int:
                     benchmark_id,
                 )
             )
+            if sink_container_id:
+                resource_sample = read_container_resource_sample(sink_container_id)
+                if resource_sample is not None:
+                    cpu_cores, rss_mb = resource_sample
+                    sink_cpu_samples.append(cpu_cores)
+                    sink_rss_samples.append(rss_mb)
             if collector_container_id:
                 resource_sample = read_container_resource_sample(collector_container_id)
                 if resource_sample is not None:
@@ -1242,6 +1251,12 @@ def main() -> int:
         if sink_rss_series and any(sample.rss_bytes > 0 for sample in sink_samples):
             result.sink_rss_mb_avg = avg(sink_rss_series)
             result.sink_rss_mb_p95 = percentile(sink_rss_series, 0.95)
+        if result.sink_cpu_cores_avg is None and sink_cpu_samples:
+            result.sink_cpu_cores_avg = avg(sink_cpu_samples)
+            result.sink_cpu_cores_p95 = percentile(sink_cpu_samples, 0.95)
+        if result.sink_rss_mb_avg is None and sink_rss_samples:
+            result.sink_rss_mb_avg = avg(sink_rss_samples)
+            result.sink_rss_mb_p95 = percentile(sink_rss_samples, 0.95)
 
         measured_sink_events: int | None = None
         measured_window_sec: float | None = None


### PR DESCRIPTION
## Summary
- remove `compose-esql-input-oracle` from default nightly suite so nightly-on-main no longer fails on unsupported `input.type: esql`
- add compose sink CPU/RSS fallback sampling from container metrics when sink diagnostics CPU counters are unavailable

## Validation
- E2E nightly suite (branch dispatch): https://github.com/strawgate/memagent-e2e/actions/runs/24291249100
- Bench compose smoke targeted run (before patch baseline): https://github.com/strawgate/memagent-e2e/actions/runs/24291317399
- Bench compose smoke targeted run (after patch): https://github.com/strawgate/memagent-e2e/actions/runs/24291343138 (Sink CPU Avg populated)
