### PR TITLE
docs: enable GitHub Pages publishing

### DIFF
--- a/.github/workflows/bench-compose-smoke.yml
+++ b/.github/workflows/bench-compose-smoke.yml
@@ -2,7 +2,7 @@ name: Bench / compose smoke
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - 'bench/compose/**'
       - 'bench/lib/**'

--- a/.github/workflows/bench-kind-smoke.yml
+++ b/.github/workflows/bench-kind-smoke.yml
@@ -2,7 +2,7 @@ name: Bench / kind smoke
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - 'bench/kind/**'
       - 'bench/lib/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "docs/**"
       - "mkdocs.yml"
@@ -57,4 +57,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
-

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -2,7 +2,7 @@ name: E2E / smoke suite
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'tests/e2e/**'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repo does **not** own the `memagent` product code. Workflows check out
 `strawgate/memagent` as the system under test and build `logfwd:e2e` from that
 checkout.
 
-When `memagent_ref` points at `main` (or legacy `master`) or a full
+When `memagent_ref` points at `main` or a full
 40-character commit SHA, the shared setup action first tries to pull a prebuilt image from
 `ghcr.io/strawgate/memagent`. It falls back to a local build when no matching
 image is available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+# memagent-e2e
+
+End-to-end and benchmark orchestration for `memagent`.
+
+This site publishes the operator-facing docs from this repository.
+
+## What this repo owns
+
+- Explicit workflow-per-scenario E2E coverage.
+- Benchmark harnesses under `bench/` for compose and KIND environments.
+- Shared scenario setup/actions and artifact/oracle plumbing.
+
+## Start here
+
+- [Scenario Platform](SCENARIO_PLATFORM.md)
+- [Repository README](https://github.com/strawgate/memagent-e2e#readme)
+- [Actions Workflows](https://github.com/strawgate/memagent-e2e/actions)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: memagent-e2e
+site_url: https://strawgate.com/memagent-e2e/
+repo_url: https://github.com/strawgate/memagent-e2e
+repo_name: strawgate/memagent-e2e
+
+theme:
+  name: mkdocs
+
+nav:
+  - Home: index.md
+  - Scenario Platform: SCENARIO_PLATFORM.md
+


### PR DESCRIPTION
## Summary

Enable a docs site for `memagent-e2e` on GitHub Pages.

## Changes

- Add `mkdocs.yml` site config.
- Add `docs/index.md` landing page.
- Add `.github/workflows/docs.yml` to build and deploy docs on push to `master`.

## Validation

- YAML parse check for workflow.
- `actionlint` on docs workflow.
- `mkdocs build --strict` succeeds locally.

## Expected site URL

- http://strawgate.com/memagent-e2e/
