### PR TITLE
fix: show n/a for vector collector CPU when process metrics unavailable

### DIFF
--- a/bench/kind/lib/measure.py
+++ b/bench/kind/lib/measure.py
@@ -333,6 +333,11 @@ def _sample_from_vector_prometheus(body: str) -> StatsSample:
             ["process_resident_memory_bytes", "vector_process_resident_memory_bytes"],
         )
     )
+    # If both process-level metrics are absent the endpoint is returning only
+    # component-level metrics (no process CPU/RSS). Raise so the caller treats
+    # this sample as unavailable rather than recording misleading zeros.
+    if process_cpu_seconds == 0.0 and rss_bytes == 0:
+        raise ValueError("vector process metrics (CPU/RSS) not present in prometheus output")
     return StatsSample(
         timestamp=time.time(),
         output_lines=int(sent_logs),

--- a/bench/kind/render_issue_summary.py
+++ b/bench/kind/render_issue_summary.py
@@ -506,6 +506,24 @@ def render_markdown(
                 lines.append(f"- Notes: {result.notes or 'n/a'}")
                 lines.append("")
 
+    # Add telemetry notes for known collection gaps
+    collectors_in_results = {r.collector for r in sorted_results}
+    if "vector" in collectors_in_results:
+        has_vector_cpu_na = any(
+            r.collector == "vector" and r.collector_cpu_cores_avg is None
+            for r in sorted_results
+        )
+        if has_vector_cpu_na:
+            lines.extend([
+                "",
+                "---",
+                "",
+                "**Telemetry Note:** Vector `Collector CPU Avg` shows `n/a` because vector's "
+                "`internal_metrics` source does not expose process-level CPU/RSS metrics in the "
+                "prometheus output captured by this harness. Throughput (EPS) measurements are "
+                "unaffected — they are derived from sink capture counts.",
+            ])
+
     return "\n".join(lines).rstrip() + "\n"
 
 


### PR DESCRIPTION
## Summary

Vector's `internal_metrics` → `prometheus_exporter` pipeline returns component-level throughput metrics but does not expose process-level CPU or RSS in the kind harness environment. Previously the harness sampled zeros and reported `0.00` collector CPU for every vector lane — indistinguishable from genuine zero usage.

### Root Cause

`_sample_from_vector_prometheus` calls `_prometheus_metric_first` for both `process_cpu_seconds_total` and `vector_process_cpu_seconds_total`. When neither metric is present in the endpoint body, the function returns `0.0` with no error. The same happens for RSS. The harness then records a StatsSample with `cpu_total_ms=0` and `rss_bytes=0` for every measurement interval, resulting in a CPU average of `0.00`.

In compose, vector CPU is measured via `docker stats` (bypassing prometheus entirely), so compose reports accurate CPU figures.

### Fix

Raise `ValueError` when both `process_cpu_seconds` and `rss_bytes` are `0` — this signals that the endpoint is returning only component-level metrics. The existing exception handler in `collect_bench_samples` already converts raised samples to `None` and skips them. With all vector samples skipped, `avg([]) = None`, which renders as `n/a` in the report.

Also adds a **Telemetry Note** footer to the report when vector CPU shows `n/a`, explaining the collection gap.

### Unchanged

- Throughput (EPS) measurements are unaffected — derived from sink capture, not collector prometheus.
- otelcol and logfwd CPU collection is unchanged.
- Report PASS/FAIL verdict is unchanged (CPU not used in gating).

## Testing

- Syntax: `python3 -c 'import bench.kind.lib.measure'` ✓
- Unit tests: `python3 -m pytest bench/kind/tests/` — 2 passed ✓
- Manual test of both the `raises-when-absent` and `succeeds-with-full-metrics` cases confirmed correct behavior.

## Related

Closes the vector CPU = 0.00 observability gap documented in the audit after PR #250.