### PR TITLE
docs: add drain-window artifact note to Integrity Alerts section

### DIFF
--- a/bench/kind/render_issue_summary.py
+++ b/bench/kind/render_issue_summary.py
@@ -360,6 +360,27 @@ def render_markdown(
                 )
             )
             lines.append("")
+            # Explain drain-window artifact: at low EPS targets, collectors with
+            # slow flush cycles (e.g. otelcol) may not finish delivering all
+            # buffered events before the drain timeout expires.  The missing count
+            # is proportional to eps_per_pod (≈ drain_timeout_sec × eps_per_pod)
+            # and is a structural artifact, not data loss.
+            has_drain_window_artifact = any(
+                r.collector != "logfwd"
+                and r.passed
+                and (r.missing_event_count or 0) > 0
+                and not is_saturation_target(r)
+                for r in sorted_results
+            )
+            if has_drain_window_artifact:
+                lines.append(
+                    "_Note: `Missing` counts on PASS rows at low EPS targets reflect a "
+                    "drain-window artifact — the collector's flush cycle extends beyond the "
+                    "10 s drain timeout, so events buffered at measurement end arrive after "
+                    "the source oracle snapshot is taken. The count scales with "
+                    "`eps_per_pod × drain_timeout_sec` and does not indicate data loss._"
+                )
+                lines.append("")
 
         for cpu_profile in cpu_profiles:
             lines.extend(["", f"## CPU: `{cpu_profile}`", ""])


### PR DESCRIPTION
## Summary

The Integrity Alerts table shows otelcol file at low EPS targets (t1–t1k) with non-zero `Missing` counts on PASS rows. This causes reader confusion — it looks like a correctness problem when it is actually structural.

### Root Cause

The drain timeout is **10 s**. otelcol's filelog receiver batches with a **1 s** timeout. At measurement end, up to ~10 s worth of in-flight events are still buffered in otelcol when the drain deadline fires. The source oracle snapshot is taken at that point, capturing those events as "emitted but not yet received". The count is consistently **≈ eps_per_pod × 10** (drain timeout), confirming it's timing-based, not data loss.

### Fix

Add a single italicized note line below the Integrity Alerts table when PASS rows with non-zero missing counts are present on non-saturation targets. The note explains the drain-window artifact and makes it clear the count does not indicate data loss.

Detection condition: `collector != 'logfwd' AND passed AND missing > 0 AND not saturation_target`

(logfwd's synchronous flush means it doesn't exhibit this pattern.)

## Testing

- `python3 -c 'import bench.kind.render_issue_summary'` ✓
- `python3 -m pytest bench/kind/tests/` — 2 passed ✓