### PR TITLE
bench(kind): fix collector CPU to exactly 1/2 cores and shorten otelcol drain timeout

### DIFF
--- a/bench/kind/manifests/collectors/otelcol-configmap.yaml.tmpl
+++ b/bench/kind/manifests/collectors/otelcol-configmap.yaml.tmpl
@@ -23,7 +23,7 @@ data:
               - merge_maps(attributes, ParseJSON(body), "upsert") where IsMatch(body, "^\\{")
       batch:
         send_batch_size: 1024
-        timeout: 1s
+        timeout: 200ms
 
     exporters:
       otlphttp:

--- a/bench/kind/manifests/collectors/otelcol-otlp-configmap.yaml.tmpl
+++ b/bench/kind/manifests/collectors/otelcol-otlp-configmap.yaml.tmpl
@@ -19,7 +19,7 @@ data:
               - merge_maps(attributes, ParseJSON(body), "upsert") where IsMatch(body, "^\\{")
       batch:
         send_batch_size: 1024
-        timeout: 1s
+        timeout: 200ms
 
     exporters:
       otlphttp:

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -103,9 +103,11 @@ class ResourcePlan:
 CPU_PROFILES: dict[str, CpuProfile] = {
     "single": CpuProfile(
         name="single",
-        cluster_cpu_cores=1.0,
+        # 2.0 cores gives the collector exactly 1 core at all EPS targets:
+        # 2000m - 100m(sink) - 20m(capture) - 5×60m(emitters) = 1580m → capped at 1000m.
+        cluster_cpu_cores=2.0,
         collector_cpu_mcpu_min=500,
-        collector_cpu_mcpu_target=900,
+        collector_cpu_mcpu_target=1000,
         emitter_cpu_mcpu_per_pod=60,
         sink_cpu_mcpu=100,
         capture_reader_cpu_mcpu=20,
@@ -116,9 +118,11 @@ CPU_PROFILES: dict[str, CpuProfile] = {
     ),
     "multi": CpuProfile(
         name="multi",
-        cluster_cpu_cores=2.0,
+        # 3.0 cores gives the collector exactly 2 cores at all EPS targets:
+        # 3000m - 120m(sink) - 20m(capture) - 5×60m(emitters) = 2560m → capped at 2000m.
+        cluster_cpu_cores=3.0,
         collector_cpu_mcpu_min=1200,
-        collector_cpu_mcpu_target=1800,
+        collector_cpu_mcpu_target=2000,
         emitter_cpu_mcpu_per_pod=60,
         sink_cpu_mcpu=120,
         capture_reader_cpu_mcpu=20,
@@ -278,7 +282,7 @@ def build_resource_plan(
             sink_mcpu = 850
             capture_reader_mcpu = 50
             collector_mcpu_min = 1400
-            collector_mcpu_target = 1400
+            collector_mcpu_target = 2000
 
     reserved_mcpu = sink_mcpu + capture_reader_mcpu
     if capacity_probe:


### PR DESCRIPTION
## Summary

Two related fixes for fairness and clean integrity metrics in kind benchmarks.

### 1. Collector CPU parity (kind == compose)

Previously at low-EPS targets (t1–t1k, eps_per_pod < 10000), the single-profile kind resource plan allocated only **~580m (0.58 cores)** to the collector because the node budget was 1000m total and emitters + sink consumed the rest. The capacity-probe path (eps ≥ 10k) already gave exactly 1000m via an explicit override. Compose always gives a flat 1.0 / 2.0 cores.

**Fix:** increase the kind cluster CPU budget so there's room to give the collector its full allocation at all EPS targets:

| Profile | Before | After |
|---------|--------|-------|
| single cluster budget | 1000m | 2000m |
| single collector target | 900m | **1000m** (exactly 1 core) |
| multi cluster budget | 2000m | 3000m |
| multi collector target | 1800m | **2000m** (exactly 2 cores) |
| multi capacity-probe target | 1400m | **2000m** |

Math check (smoke: 5 pods × 60m = 300m emitter total):
- Single: 2000m − 120m(sink+capture) − 300m(emitters) = 1580m → capped at 1000m ✓
- Multi: 3000m − 140m − 300m = 2560m → capped at 2000m ✓
- Multi capacity-probe: 4000m − 850m − 50m − 900m = 2200m → capped at 2000m ✓

GH Actions runners have 4 logical cores. The existing multi capacity-probe path already uses 4000m without issues. 2000m/3000m for the base profiles is well within headroom.

### 2. otelcol batch timeout: 1s → 200ms

otelcol's  was 1s. At low EPS targets the harness's 10s drain deadline would expire before the last second's worth of events flushed through otelcol's batch processor, causing reports to show:



At high EPS the batch fills to  well before the timeout fires, so reducing the timeout to **200ms** has zero throughput impact. At low EPS, events now flush within 200ms of drain start — well within the 10s deadline.

Both file and otlp configmaps updated.

## Testing

-  parse check ✓
- ============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/bill_easton/memagent-e2e
collected 2 items

bench/kind/tests/test_diagnostics.py ..                                  [100%]

============================== 2 passed in 0.01s =============================== — 2 passed ✓
- CI run after merge will validate live