### PR TITLE
fix: raise emitter rollout timeout floor 120s → 300s

### DIFF
--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -785,7 +785,7 @@ def run_smoke_phase(
 
     apply_manifest(manifests["emitter_configmap"])
     apply_manifest(manifests["emitter_statefulset"])
-    emitter_rollout_timeout = max(120, profile.pods * 12)
+    emitter_rollout_timeout = max(300, profile.pods * 12)
     rollout_status(args.namespace, "statefulset", "log-emitter", timeout_sec=emitter_rollout_timeout)
     emitter_pods = get_pod_names(args.namespace, "app.kubernetes.io/name=log-emitter")
     collector_restart_before, collector_reasons_before = collector_runtime_snapshot(args.namespace, collector_pod)


### PR DESCRIPTION
## Summary

All 5 gating failures in run [#24382458661](https://github.com/strawgate/memagent-e2e/actions/runs/24382458661) were:

```
CommandError: command failed (kubectl -n memagent-bench rollout status statefulset/log-emitter --timeout=120s): exit code 1
```

Every failure was `multi / target=10000` across all collectors — a clear signal this is runner-load flakiness, not a code regression.

## Root cause

`emitter_rollout_timeout = max(120, profile.pods * 12)` evaluates to 120s for the smoke profile (5 pods × 12 = 60s < 120s). Loaded GH Actions runners take longer to pull images and schedule pods under kind.

## Fix

Raise the floor from 120s → 300s, matching the collector rollout timeout set in PR #250.

## Test plan

Re-trigger `bench-kind-smoke.yml` with `target_set=ladder_and_max` after merge.

Closes #259