### PR TITLE
fix: accept float seq values in filter_rows_to_emitter_snapshot

### DIFF
--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -524,9 +524,10 @@ def filter_rows_to_emitter_snapshot(
     seq_bounds_by_pod: dict[str, tuple[int, int]] = {}
     for row in rows:
         pod_name = row.get("pod_name")
-        seq = row.get("seq")
-        if not isinstance(pod_name, str) or not isinstance(seq, int):
+        seq_raw = row.get("seq")
+        if not isinstance(pod_name, str) or not isinstance(seq_raw, (int, float)):
             continue
+        seq = int(seq_raw)
         bounds = seq_bounds_by_pod.get(pod_name)
         if bounds is None:
             seq_bounds_by_pod[pod_name] = (seq, seq)
@@ -538,7 +539,7 @@ def filter_rows_to_emitter_snapshot(
     for stat in emitter_reported_stats:
         pod_name = stat.get("pod_name")
         output_lines = stat.get("output_lines")
-        if isinstance(pod_name, str) and isinstance(output_lines, int):
+        if isinstance(pod_name, str) and isinstance(output_lines, (int, float)):
             bounds = seq_bounds_by_pod.get(pod_name)
             if bounds is None:
                 continue
@@ -546,14 +547,15 @@ def filter_rows_to_emitter_snapshot(
             # `output_lines` is a count, not an absolute sequence number.
             # Sequence values can begin well above 1, so anchor the cutoff to
             # the first observed sequence for this benchmark snapshot.
-            cutoff_by_pod[pod_name] = min_seq + max(0, output_lines - 1)
+            cutoff_by_pod[pod_name] = min_seq + max(0, int(output_lines) - 1)
 
     filtered: list[dict[str, object]] = []
     for row in rows:
         pod_name = row.get("pod_name")
-        seq = row.get("seq")
-        if not isinstance(pod_name, str) or not isinstance(seq, int):
+        seq_raw = row.get("seq")
+        if not isinstance(pod_name, str) or not isinstance(seq_raw, (int, float)):
             continue
+        seq = int(seq_raw)
         cutoff = cutoff_by_pod.get(pod_name)
         if cutoff is None or seq <= cutoff:
             filtered.append(row)


### PR DESCRIPTION
## Problem

otelcol OTTL converts integer JSON attributes (`seq`, `status`, `duration_ms`, etc.) to **float** when forwarding via OTLP. The `isinstance(seq, int)` guard in `filter_rows_to_emitter_snapshot` silently dropped every otelcol sink row, producing `missing_event_count == emitter_total` at **all** file-ingest lanes at low EPS targets.

Pattern observed in reports: `missing = 30 × eps_per_pod` (exactly the total emitter output), which is `source_row_count` with `sink_row_count = 0`.

Root cause confirmed by inspecting artifact `sink-capture.ndjson` from run #24383573284:
- Capture file had **41 lines**, 30 with matching `benchmark_id`
- But `seq` values were `1.0`, `2.0`, ... (float) — failing the `isinstance(seq, int)` check
- Fix: `sink_row_count` 0 → 30 for the otelcol file t1 single lane

## Fix

Accept `(int, float)` and coerce to `int` immediately so all sequence range arithmetic is unchanged. Same tolerance applied to `output_lines` for consistency.

## Test Plan

Re-run `bench-kind-smoke.yml` with `target_set=ladder_and_max` and confirm otelcol file-ingest lanes show `missing_event_count = 0` at t1/t10/t100/t1k targets.

Closes #262