### PR TITLE
feat(bench): collect collector CPU flamegraph as bench artifact

### DIFF
--- a/bench/kind/lib/kube.py
+++ b/bench/kind/lib/kube.py
@@ -159,16 +159,16 @@ def send_signal_to_pod(namespace: str, pod_name: str, signal: str) -> None:
     )
 
 
-def collect_flamegraph_from_pod(namespace: str, pod_name: str, dest: Path) -> None:
-    """Copy flamegraph.svg from a pod to a local path via kubectl cp."""
+def collect_pprof_from_pod(namespace: str, pod_name: str, dest: Path) -> None:
+    """Copy profile.pb.gz from a pod to a local path via kubectl cp."""
     completed = subprocess.run(
-        ["kubectl", "-n", namespace, "cp", f"{pod_name}:/flamegraph.svg", str(dest)],
+        ["kubectl", "-n", namespace, "cp", f"{pod_name}:/profile.pb.gz", str(dest)],
         check=False,
         capture_output=True,
         text=True,
     )
     if completed.returncode != 0:
-        raise CommandError(f"kubectl cp flamegraph failed: {completed.stderr.strip()}")
+        raise CommandError(f"kubectl cp pprof failed: {completed.stderr.strip()}")
 
 
 def wait_for_namespace(namespace: str, timeout_sec: int = 15) -> None:

--- a/bench/kind/lib/kube.py
+++ b/bench/kind/lib/kube.py
@@ -149,6 +149,28 @@ def collect_debug_artifacts(
                 (artifacts_dir / suffix).write_text(output, encoding="utf-8")
 
 
+def send_signal_to_pod(namespace: str, pod_name: str, signal: str) -> None:
+    """Send a signal to PID 1 in a running pod via kubectl exec."""
+    subprocess.run(
+        ["kubectl", "-n", namespace, "exec", pod_name, "--", "kill", f"-{signal}", "1"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def collect_flamegraph_from_pod(namespace: str, pod_name: str, dest: Path) -> None:
+    """Copy flamegraph.svg from a pod to a local path via kubectl cp."""
+    completed = subprocess.run(
+        ["kubectl", "-n", namespace, "cp", f"{pod_name}:/flamegraph.svg", str(dest)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise CommandError(f"kubectl cp flamegraph failed: {completed.stderr.strip()}")
+
+
 def wait_for_namespace(namespace: str, timeout_sec: int = 15) -> None:
     deadline = time.time() + timeout_sec
     while time.time() < deadline:

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -34,7 +34,7 @@ from lib.diagnostics import analyze_delivery_diagnostics
 from lib.kube import (
     apply_manifest,
     collect_debug_artifacts,
-    collect_flamegraph_from_pod,
+    collect_pprof_from_pod,
     get_first_pod_name,
     get_pod_names,
     rollout_status,
@@ -966,19 +966,19 @@ def run_smoke_phase(
         )
     except Exception as exc:  # noqa: BLE001
         append_artifact_note(results_dir, "collector-status-error.txt", str(exc))
-    # Collect a CPU flamegraph from the collector pod.
-    # Sending SIGUSR1 triggers logfwd to write flamegraph.svg then begin graceful shutdown.
+    # Collect a pprof profile from the collector pod.
+    # Sending SIGUSR1 triggers logfwd to write profile.pb.gz then begin graceful shutdown.
     # We copy the file in the short window between write and process exit.
     try:
         send_signal_to_pod(args.namespace, collector_pod_after, "USR1")
         time.sleep(2)
-        collect_flamegraph_from_pod(
+        collect_pprof_from_pod(
             args.namespace,
             collector_pod_after,
-            artifacts_dir / "collector-flamegraph.svg",
+            artifacts_dir / "collector-pprof.pb.gz",
         )
     except Exception as exc:  # noqa: BLE001
-        append_artifact_note(results_dir, "collector-flamegraph-error.txt", str(exc))
+        append_artifact_note(results_dir, "collector-pprof-error.txt", str(exc))
     collect_pod_logs(
         namespace=args.namespace,
         pod_names=[sink_pod],

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -34,9 +34,11 @@ from lib.diagnostics import analyze_delivery_diagnostics
 from lib.kube import (
     apply_manifest,
     collect_debug_artifacts,
+    collect_flamegraph_from_pod,
     get_first_pod_name,
     get_pod_names,
     rollout_status,
+    send_signal_to_pod,
     wait_for_deployment,
     wait_for_namespace,
 )
@@ -964,6 +966,19 @@ def run_smoke_phase(
         )
     except Exception as exc:  # noqa: BLE001
         append_artifact_note(results_dir, "collector-status-error.txt", str(exc))
+    # Collect a CPU flamegraph from the collector pod.
+    # Sending SIGUSR1 triggers logfwd to write flamegraph.svg then begin graceful shutdown.
+    # We copy the file in the short window between write and process exit.
+    try:
+        send_signal_to_pod(args.namespace, collector_pod_after, "USR1")
+        time.sleep(2)
+        collect_flamegraph_from_pod(
+            args.namespace,
+            collector_pod_after,
+            artifacts_dir / "collector-flamegraph.svg",
+        )
+    except Exception as exc:  # noqa: BLE001
+        append_artifact_note(results_dir, "collector-flamegraph-error.txt", str(exc))
     collect_pod_logs(
         namespace=args.namespace,
         pod_names=[sink_pod],


### PR DESCRIPTION
Add `send_signal_to_pod` and `collect_flamegraph_from_pod` helpers to `bench/kind/lib/kube.py`, then wire them into `run.py` after the collector-status artifact collection.

Sending `SIGUSR1` to PID 1 triggers logfwd (built with `cpu-profiling`) to flush `flamegraph.svg` and begin graceful shutdown. We sleep 2 s to allow the write to complete, then `kubectl cp` the file out as `collector-flamegraph.svg`. Failures are non-fatal and logged to `collector-flamegraph-error.txt`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>