### PR TITLE
fix(bench): raise OTLP collector max_request_body_size to 100MB

### DIFF
--- a/bench/kind/manifests/collectors/logfwd-otlp-configmap.yaml.tmpl
+++ b/bench/kind/manifests/collectors/logfwd-otlp-configmap.yaml.tmpl
@@ -17,6 +17,7 @@ data:
         inputs:
           - type: otlp
             listen: 0.0.0.0:4318
+            max_request_body_size: 104857600
 
         transform: |
           SELECT


### PR DESCRIPTION
## Problem

At `tmax` (unlimited EPS), the logfwd emitter builds large batches (21k+ rows) before flushing to the OTLP collector. The collector's default 10MB body limit rejects these with **HTTP 413**, causing:
- The emitter's readiness probe to fail (503)
- The StatefulSet rollout to time out (300s)
- The harness to exit before the benchmark starts
- `n/a` in the Max EPS snapshot for all OTLP lanes

## Fix

Add `max_request_body_size: 104857600` (100MB) to the logfwd OTLP collector config template. This allows the collector to accept large payloads from a flat-out emitter.

## Impact

Only affects the OTLP ingest mode collector config. File-ingest and other templates are unaffected.