### PR TITLE
fix(bench): cap OTLP emitter batch to 4MB, revert 100MB collector limit

### DIFF
--- a/bench/kind/manifests/collectors/logfwd-otlp-configmap.yaml.tmpl
+++ b/bench/kind/manifests/collectors/logfwd-otlp-configmap.yaml.tmpl
@@ -17,7 +17,6 @@ data:
         inputs:
           - type: otlp
             listen: 0.0.0.0:4318
-            max_request_body_size: 104857600
 
         transform: |
           SELECT

--- a/bench/kind/manifests/workload/log-emitter-configmap-otlp.yaml.tmpl
+++ b/bench/kind/manifests/workload/log-emitter-configmap-otlp.yaml.tmpl
@@ -46,3 +46,4 @@ data:
     output:
       type: otlp
       endpoint: http://bench-collector.${NAMESPACE}.svc.cluster.local:4318/v1/logs
+      batch_target_bytes: 4194304


### PR DESCRIPTION
## Problem

The previous fix (#278) unblocked OTLP tmax runs by raising the collector body limit to 100MB, but the underlying issue was that the emitter was sending unrealistically large batches (~21k rows, >>10MB). This makes the benchmark measure single-request throughput rather than realistic OTLP request-rate throughput.

## Fix

- Add `batch_target_bytes: 4194304` to the emitter's OTLP output config (4MB cap — representative of real-world OTLP batch sizes)
- Revert the 100MB `max_request_body_size` on the collector (no longer needed; default 10MB is fine for 4MB batches)