### PR TITLE
feat: add OTLP batch-size matrix (100kb / 4mb) to kind benchmark

### DIFF
--- a/.codex/refresh/refresh-20260414-051616.md
+++ b/.codex/refresh/refresh-20260414-051616.md
@@ -1,0 +1,576 @@
+# Refresh Snapshot
+
+- Generated (UTC): 2026-04-14T05:16:16Z
+- Repo root: /home/bill_easton/memagent-e2e
+- Current cwd: /home/bill_easton/memagent-e2e
+- Repo: strawgate/memagent-e2e
+- Default branch: main
+- Repo URL: https://github.com/strawgate/memagent-e2e
+
+## Working Tree
+
+### git status -sb
+
+```text
+## main...origin/main
+?? .codex/
+```
+
+### current branch
+
+```text
+main
+```
+
+### HEAD
+
+```text
+56268a948e1218973389e7c79a8d6678e084bcd3
+```
+
+## Recent Commits
+
+### current branch commits (latest 40)
+
+```text
+56268a94 2026-04-12 Bill Easton docs: add drain-window artifact note to Integrity Alerts section (#254)
+dcb182ed 2026-04-12 Bill Easton fix: show n/a for vector collector CPU when process metrics are unavailable (#253)
+7e45231b 2026-04-12 Bill Easton fix: stabilize kind nightly EPS for saturation-target lanes (#250)
+466047a9 2026-04-12 strawgate docs: point mkdocs edit links to main
+d57950ef 2026-04-12 Bill Easton docs: enable GitHub Pages publishing
+a5d254b2 2026-04-11 Bill Easton bench/e2e: stabilize nightly main and fill compose sink CPU (#242)
+beda1aa8 2026-04-11 Bill Easton bench/e2e cleanup: dedupe workflows, tighten scenario defaults, prune stale assets (#197)
+bdfb0c69 2026-04-10 Bill Easton bench(kind): increase shared OTLP max collector memory to 4Gi (#184)
+107273e3 2026-04-10 Bill Easton bench(kind): fail lanes on collector instability and clean sampling (#181)
+0c083bd6 2026-04-10 Bill Easton Merge pull request #177 from strawgate/codex/kind-sampler-transient-fallback
+cadc9998 2026-04-10 strawgate bench(kind): tolerate transient diagnostics sample drops
+033c577e 2026-04-10 Bill Easton Merge pull request #172 from strawgate/codex/kind-low-eps-batch-shape
+e9b72513 2026-04-10 strawgate bench(kind): scale generator batch size to target eps
+2edf948a 2026-04-10 Bill Easton Merge pull request #170 from strawgate/codex/kind-otelcol-tmax-memory-headroom
+6712a0ad 2026-04-10 strawgate bench(kind): add otelcol tmax OTLP memory headroom
+6c855c52 2026-04-10 Bill Easton Merge pull request #165 from strawgate/codex/bench-report-suite-key-by-targetset
+9efe605f 2026-04-10 strawgate ci(bench): scope report suite keys by target set
+9d717f96 2026-04-10 Bill Easton Merge pull request #161 from strawgate/codex/bench-kind-stats-and-capture-settle
+5c217884 2026-04-10 strawgate bench(kind): harden stats polling and sink capture settling
+3d30de6f 2026-04-09 Bill Easton test(e2e): add ES|QL input oracle scenario (#142)
+f702f584 2026-04-09 Bill Easton bench: fail CI when single-lane CPU avg exceeds envelope (#160)
+de78428f 2026-04-09 Bill Easton bench: harden kind/compose workflow reliability and high-target handling (#158)
+c86112d2 2026-04-09 Bill Easton bench(compose): treat high-target integrity deltas as saturation signals (#148)
+8611180c 2026-04-09 Bill Easton bench/kind: fix false degraded-source oracles and sink bottleneck in capacity probes (#124)
+12c922c5 2026-04-09 Bill Easton CI: artifact v5 migration + kind benchmark truthfulness gate (#109)
+271ada99 2026-04-08 Bill Easton bench: add sink CPU and RSS diagnostics to kind results (#82)
+acbd4f21 2026-04-08 Bill Easton Compose bench: add filebeat, strict integrity checks, and report cleanup (#94)
+92e6b850 2026-04-08 Bill Easton Compose bench: ingest matrix, monitor merge, strict summary gate (#91)
+15045372 2026-04-08 Bill Easton Add non-KIND compose benchmark harness (#85)
+211d46c7 2026-04-07 Bill Easton Add target EPS ladder and max-throughput benchmark mode (#14)
+d11cbfed 2026-04-07 Bill Easton Add nightly EPS benchmark suite summary and reporting (#12)
+64852612 2026-04-07 Bill Easton Merge pull request #11 from strawgate/codex/bench-aggregate-auth-header
+838c1182 2026-04-07 strawgate Fix bench aggregate auth header collision
+946a52a7 2026-04-07 Bill Easton Merge pull request #10 from strawgate/codex/e2e-memcached-log-permission
+d2a3d205 2026-04-07 strawgate Fix compose memcached log file permissions
+6a9c19d5 2026-04-07 Bill Easton Merge pull request #9 from strawgate/codex/bench-workflow-reliability
+f1cdf519 2026-04-07 strawgate Harden benchmark workflow against vector and stash races
+00b1b3c2 2026-04-07 Bill Easton Use main fallback for smoke suite otlp oracle (#8)
+67d5808a 2026-04-07 Bill Easton Add CPU profile constraints for KIND benchmark runs (#7)
+5a59e99a 2026-04-07 Bill Easton Add Vector KIND benchmark adapter (#6)```
+
+### origin/main commits (latest 40)
+
+```text
+56268a94 2026-04-12 Bill Easton docs: add drain-window artifact note to Integrity Alerts section (#254)
+dcb182ed 2026-04-12 Bill Easton fix: show n/a for vector collector CPU when process metrics are unavailable (#253)
+7e45231b 2026-04-12 Bill Easton fix: stabilize kind nightly EPS for saturation-target lanes (#250)
+466047a9 2026-04-12 strawgate docs: point mkdocs edit links to main
+d57950ef 2026-04-12 Bill Easton docs: enable GitHub Pages publishing
+a5d254b2 2026-04-11 Bill Easton bench/e2e: stabilize nightly main and fill compose sink CPU (#242)
+beda1aa8 2026-04-11 Bill Easton bench/e2e cleanup: dedupe workflows, tighten scenario defaults, prune stale assets (#197)
+bdfb0c69 2026-04-10 Bill Easton bench(kind): increase shared OTLP max collector memory to 4Gi (#184)
+107273e3 2026-04-10 Bill Easton bench(kind): fail lanes on collector instability and clean sampling (#181)
+0c083bd6 2026-04-10 Bill Easton Merge pull request #177 from strawgate/codex/kind-sampler-transient-fallback
+cadc9998 2026-04-10 strawgate bench(kind): tolerate transient diagnostics sample drops
+033c577e 2026-04-10 Bill Easton Merge pull request #172 from strawgate/codex/kind-low-eps-batch-shape
+e9b72513 2026-04-10 strawgate bench(kind): scale generator batch size to target eps
+2edf948a 2026-04-10 Bill Easton Merge pull request #170 from strawgate/codex/kind-otelcol-tmax-memory-headroom
+6712a0ad 2026-04-10 strawgate bench(kind): add otelcol tmax OTLP memory headroom
+6c855c52 2026-04-10 Bill Easton Merge pull request #165 from strawgate/codex/bench-report-suite-key-by-targetset
+9efe605f 2026-04-10 strawgate ci(bench): scope report suite keys by target set
+9d717f96 2026-04-10 Bill Easton Merge pull request #161 from strawgate/codex/bench-kind-stats-and-capture-settle
+5c217884 2026-04-10 strawgate bench(kind): harden stats polling and sink capture settling
+3d30de6f 2026-04-09 Bill Easton test(e2e): add ES|QL input oracle scenario (#142)
+f702f584 2026-04-09 Bill Easton bench: fail CI when single-lane CPU avg exceeds envelope (#160)
+de78428f 2026-04-09 Bill Easton bench: harden kind/compose workflow reliability and high-target handling (#158)
+c86112d2 2026-04-09 Bill Easton bench(compose): treat high-target integrity deltas as saturation signals (#148)
+8611180c 2026-04-09 Bill Easton bench/kind: fix false degraded-source oracles and sink bottleneck in capacity probes (#124)
+12c922c5 2026-04-09 Bill Easton CI: artifact v5 migration + kind benchmark truthfulness gate (#109)
+271ada99 2026-04-08 Bill Easton bench: add sink CPU and RSS diagnostics to kind results (#82)
+acbd4f21 2026-04-08 Bill Easton Compose bench: add filebeat, strict integrity checks, and report cleanup (#94)
+92e6b850 2026-04-08 Bill Easton Compose bench: ingest matrix, monitor merge, strict summary gate (#91)
+15045372 2026-04-08 Bill Easton Add non-KIND compose benchmark harness (#85)
+211d46c7 2026-04-07 Bill Easton Add target EPS ladder and max-throughput benchmark mode (#14)
+d11cbfed 2026-04-07 Bill Easton Add nightly EPS benchmark suite summary and reporting (#12)
+64852612 2026-04-07 Bill Easton Merge pull request #11 from strawgate/codex/bench-aggregate-auth-header
+838c1182 2026-04-07 strawgate Fix bench aggregate auth header collision
+946a52a7 2026-04-07 Bill Easton Merge pull request #10 from strawgate/codex/e2e-memcached-log-permission
+d2a3d205 2026-04-07 strawgate Fix compose memcached log file permissions
+6a9c19d5 2026-04-07 Bill Easton Merge pull request #9 from strawgate/codex/bench-workflow-reliability
+f1cdf519 2026-04-07 strawgate Harden benchmark workflow against vector and stash races
+00b1b3c2 2026-04-07 Bill Easton Use main fallback for smoke suite otlp oracle (#8)
+67d5808a 2026-04-07 Bill Easton Add CPU profile constraints for KIND benchmark runs (#7)
+5a59e99a 2026-04-07 Bill Easton Add Vector KIND benchmark adapter (#6)```
+
+### files changed on origin/main across last 40 commits
+
+```text
+A	.github/actions/checkout-memagent/action.yml
+M	.github/actions/collect-e2e-artifacts/action.yml
+M	.github/actions/setup-memagent-build/action.yml
+A	.github/workflows/_scenario-compose.yml
+A	.github/workflows/_scenario-kind.yml
+A	.github/workflows/_scenario-otlp.yml
+A	.github/workflows/bench-compose-smoke.yml
+A	.github/workflows/bench-kind-aggregate.yml
+A	.github/workflows/bench-kind-smoke.yml
+A	.github/workflows/docs.yml
+A	.github/workflows/e2e-compose-esql-input-oracle.yml
+M	.github/workflows/e2e-compose-memcached.yml
+M	.github/workflows/e2e-compose-nginx.yml
+M	.github/workflows/e2e-compose-redis.yml
+M	.github/workflows/e2e-compose-synthetic-burst.yml
+M	.github/workflows/e2e-compose-synthetic-multiline.yml
+M	.github/workflows/e2e-compose-synthetic-rotation.yml
+M	.github/workflows/e2e-kind-cri-smoke.yml
+M	.github/workflows/e2e-nightly.yml
+M	.github/workflows/e2e-otlp-input-oracle.yml
+M	.github/workflows/e2e-otlp-output-oracle.yml
+M	.github/workflows/e2e-smoke.yml
+M	.gitignore
+M	README.md
+A	bench/compose/README.md
+A	bench/compose/run.py
+A	bench/kind/README.md
+A	bench/kind/RESULT_SCHEMA.md
+A	bench/kind/lib/analyze.py
+A	bench/kind/lib/cluster.py
+A	bench/kind/lib/collectors.py
+A	bench/kind/lib/diagnostics.py
+A	bench/kind/lib/kube.py
+A	bench/kind/lib/measure.py
+A	bench/kind/lib/profiles.py
+A	bench/kind/lib/results.py
+A	bench/kind/manifests/collectors/logfwd-configmap.yaml.tmpl
+A	bench/kind/manifests/collectors/logfwd-daemonset.yaml.tmpl
+A	bench/kind/manifests/collectors/logfwd-otlp-configmap.yaml.tmpl
+A	bench/kind/manifests/collectors/logfwd-otlp-daemonset.yaml.tmpl
+A	bench/kind/manifests/collectors/otelcol-configmap.yaml.tmpl
+A	bench/kind/manifests/collectors/otelcol-daemonset.yaml.tmpl
+A	bench/kind/manifests/collectors/otelcol-otlp-configmap.yaml.tmpl
+A	bench/kind/manifests/collectors/otelcol-otlp-daemonset.yaml.tmpl
+A	bench/kind/manifests/collectors/vector-configmap.yaml.tmpl
+A	bench/kind/manifests/collectors/vector-daemonset.yaml.tmpl
+A	bench/kind/manifests/common/namespace.yaml
+A	bench/kind/manifests/common/sink-configmap.yaml.tmpl
+A	bench/kind/manifests/common/sink-deployment.yaml.tmpl
+A	bench/kind/manifests/workload/log-emitter-configmap-otlp.yaml.tmpl
+A	bench/kind/manifests/workload/log-emitter-configmap.yaml.tmpl
+A	bench/kind/manifests/workload/log-emitter-statefulset.yaml.tmpl
+A	bench/kind/render_issue_summary.py
+A	bench/kind/run.py
+A	bench/kind/tests/test_diagnostics.py
+A	bench/lib/write_missing_result.py
+A	docs/SCENARIO_PLATFORM.md
+A	docs/index.md
+A	mkdocs.yml
+A	reporting/__init__.py
+A	reporting/markdown.py
+M	tests/e2e/README.md
+D	tests/e2e/lib/capture_http.py
+A	tests/e2e/lib/check_scenarios.py
+M	tests/e2e/lib/common.sh
+M	tests/e2e/lib/oracle.py
+A	tests/e2e/lib/otlp_oracle.sh
+M	tests/e2e/lib/render_issue_summary.py
+A	tests/e2e/lib/source_evidence.py
+M	tests/e2e/lib/upsert_issue.sh
+D	tests/e2e/manifests/blackhole-receiver.yaml
+D	tests/e2e/manifests/log-generator.yaml
+D	tests/e2e/manifests/logfwd-config.yaml
+D	tests/e2e/manifests/logfwd-daemonset.yaml
+M	tests/e2e/run-scenario.sh
+D	tests/e2e/run.sh
+A	tests/e2e/scenarios/compose-esql-input-oracle/compose.yaml
+A	tests/e2e/scenarios/compose-esql-input-oracle/memagent.yaml
+A	tests/e2e/scenarios/compose-esql-input-oracle/oracle.json
+A	tests/e2e/scenarios/compose-esql-input-oracle/run_workload.sh
+A	tests/e2e/scenarios/compose-esql-input-oracle/up.sh
+D	tests/e2e/scenarios/compose-memcached/collect.sh
+M	tests/e2e/scenarios/compose-memcached/compose.yaml
+D	tests/e2e/scenarios/compose-memcached/down.sh
+M	tests/e2e/scenarios/compose-memcached/memagent.yaml
+M	tests/e2e/scenarios/compose-memcached/oracle.json
+M	tests/e2e/scenarios/compose-memcached/run_workload.sh
+D	tests/e2e/scenarios/compose-memcached/verify.sh
+D	tests/e2e/scenarios/compose-nginx/collect.sh
+M	tests/e2e/scenarios/compose-nginx/compose.yaml
+D	tests/e2e/scenarios/compose-nginx/down.sh
+M	tests/e2e/scenarios/compose-nginx/memagent.yaml
+M	tests/e2e/scenarios/compose-nginx/oracle.json
+M	tests/e2e/scenarios/compose-nginx/run_workload.sh
+D	tests/e2e/scenarios/compose-nginx/up.sh
+D	tests/e2e/scenarios/compose-nginx/verify.sh
+D	tests/e2e/scenarios/compose-redis/collect.sh
+M	tests/e2e/scenarios/compose-redis/compose.yaml
+D	tests/e2e/scenarios/compose-redis/down.sh
+M	tests/e2e/scenarios/compose-redis/memagent.yaml
+M	tests/e2e/scenarios/compose-redis/oracle.json
+M	tests/e2e/scenarios/compose-redis/run_workload.sh
+D	tests/e2e/scenarios/compose-redis/up.sh
+D	tests/e2e/scenarios/compose-redis/verify.sh
+D	tests/e2e/scenarios/compose-synthetic-burst/collect.sh
+M	tests/e2e/scenarios/compose-synthetic-burst/compose.yaml
+D	tests/e2e/scenarios/compose-synthetic-burst/down.sh
+M	tests/e2e/scenarios/compose-synthetic-burst/memagent.yaml
+M	tests/e2e/scenarios/compose-synthetic-burst/oracle.json
+M	tests/e2e/scenarios/compose-synthetic-burst/run_workload.sh
+D	tests/e2e/scenarios/compose-synthetic-burst/up.sh
+D	tests/e2e/scenarios/compose-synthetic-burst/verify.sh
+D	tests/e2e/scenarios/compose-synthetic-multiline/collect.sh
+M	tests/e2e/scenarios/compose-synthetic-multiline/compose.yaml
+D	tests/e2e/scenarios/compose-synthetic-multiline/down.sh
+M	tests/e2e/scenarios/compose-synthetic-multiline/memagent.yaml
+M	tests/e2e/scenarios/compose-synthetic-multiline/oracle.json
+M	tests/e2e/scenarios/compose-synthetic-multiline/run_workload.sh
+D	tests/e2e/scenarios/compose-synthetic-multiline/up.sh
+D	tests/e2e/scenarios/compose-synthetic-multiline/verify.sh
+D	tests/e2e/scenarios/compose-synthetic-rotation/collect.sh
+M	tests/e2e/scenarios/compose-synthetic-rotation/compose.yaml
+D	tests/e2e/scenarios/compose-synthetic-rotation/down.sh
+M	tests/e2e/scenarios/compose-synthetic-rotation/memagent.yaml
+M	tests/e2e/scenarios/compose-synthetic-rotation/oracle.json
+M	tests/e2e/scenarios/compose-synthetic-rotation/run_workload.sh
+D	tests/e2e/scenarios/compose-synthetic-rotation/up.sh
+D	tests/e2e/scenarios/compose-synthetic-rotation/verify.sh
+M	tests/e2e/scenarios/kind-cri-smoke/manifests/capture-receiver.yaml
+M	tests/e2e/scenarios/kind-cri-smoke/manifests/log-generator.yaml
+M	tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-config.yaml
+M	tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-daemonset.yaml
+M	tests/e2e/scenarios/kind-cri-smoke/oracle.json
+M	tests/e2e/scenarios/kind-cri-smoke/run_workload.sh
+M	tests/e2e/scenarios/kind-cri-smoke/up.sh
+M	tests/e2e/scenarios/kind-cri-smoke/verify.sh
+D	tests/e2e/scenarios/otlp-input-oracle/down.sh
+M	tests/e2e/scenarios/otlp-input-oracle/run_workload.sh
+D	tests/e2e/scenarios/otlp-input-oracle/up.sh
+M	tests/e2e/scenarios/otlp-input-oracle/verify.sh
+D	tests/e2e/scenarios/otlp-output-oracle/down.sh
+M	tests/e2e/scenarios/otlp-output-oracle/run_workload.sh
+D	tests/e2e/scenarios/otlp-output-oracle/up.sh
+M	tests/e2e/scenarios/otlp-output-oracle/verify.sh
+```
+
+## GitHub Activity
+
+### recent PRs (state=all, limit=30)
+
+```text
+#254 MERGED docs: add drain-window artifact note to Integrity Alerts section (strawgate) updated=2026-04-13T02:46:54Z base=main head=fix/report-clarity-notes https://github.com/strawgate/memagent-e2e/pull/254
+#253 MERGED fix: show n/a for vector collector CPU when process metrics unavailable (strawgate) updated=2026-04-13T02:45:24Z base=main head=fix/vector-cpu-telemetry-gap https://github.com/strawgate/memagent-e2e/pull/253
+#250 MERGED fix: stabilize kind nightly EPS for saturation-target lanes (strawgate) updated=2026-04-13T00:06:34Z base=main head=fix/kind-nightly-saturation-stability https://github.com/strawgate/memagent-e2e/pull/250
+#248 MERGED docs: enable GitHub Pages publishing (strawgate) updated=2026-04-12T17:52:55Z base=main head=codex/docs-pages-enable https://github.com/strawgate/memagent-e2e/pull/248
+#242 MERGED bench/e2e: stabilize nightly main and fill compose sink CPU (strawgate) updated=2026-04-11T20:54:28Z base=master head=codex/nightly-main-stability https://github.com/strawgate/memagent-e2e/pull/242
+#197 MERGED bench/e2e cleanup: dedupe workflows, tighten scenario defaults, prune stale assets (strawgate) updated=2026-04-11T20:42:09Z base=master head=codex/otlp-rejection-diagnostics https://github.com/strawgate/memagent-e2e/pull/197
+#184 MERGED bench(kind): increase shared OTLP max collector memory to 4Gi (strawgate) updated=2026-04-11T01:20:08Z base=master head=codex/otlp-max-memory-4g https://github.com/strawgate/memagent-e2e/pull/184
+#181 MERGED bench(kind): gate unstable collector lanes and remove sample backfill bias (strawgate) updated=2026-04-11T00:48:16Z base=master head=codex/bench-instability-gate https://github.com/strawgate/memagent-e2e/pull/181
+#177 MERGED bench(kind): tolerate transient diagnostics sample drops (strawgate) updated=2026-04-10T13:58:08Z base=master head=codex/kind-sampler-transient-fallback https://github.com/strawgate/memagent-e2e/pull/177
+#172 MERGED bench(kind): smooth low-EPS ladders by scaling generator batch (strawgate) updated=2026-04-10T13:20:49Z base=master head=codex/kind-low-eps-batch-shape https://github.com/strawgate/memagent-e2e/pull/172
+#170 MERGED bench(kind): prevent otelcol tmax OTLP startup OOM (strawgate) updated=2026-04-10T13:01:38Z base=master head=codex/kind-otelcol-tmax-memory-headroom https://github.com/strawgate/memagent-e2e/pull/170
+#165 MERGED ci(bench): isolate live report threads by target set (strawgate) updated=2026-04-10T11:26:08Z base=master head=codex/bench-report-suite-key-by-targetset https://github.com/strawgate/memagent-e2e/pull/165
+#161 MERGED bench(kind): harden diagnostics polling + capture settle (strawgate) updated=2026-04-10T06:35:20Z base=master head=codex/bench-kind-stats-and-capture-settle https://github.com/strawgate/memagent-e2e/pull/161
+#160 MERGED bench: fail CI when single-lane CPU avg exceeds envelope (strawgate) updated=2026-04-10T00:26:49Z base=master head=codex/single-cpu-envelope-gate https://github.com/strawgate/memagent-e2e/pull/160
+#158 MERGED bench: harden kind/compose workflow reliability and high-target handling (strawgate) updated=2026-04-09T23:31:32Z base=master head=codex/e2e-workflow-stability https://github.com/strawgate/memagent-e2e/pull/158
+#148 MERGED bench/compose: treat high-target integrity deltas as saturation signals (strawgate) updated=2026-04-09T19:47:49Z base=master head=codex/compose-competitive-saturation-gating https://github.com/strawgate/memagent-e2e/pull/148
+#142 MERGED test(e2e): add ES|QL input oracle scenario (strawgate) updated=2026-04-10T00:26:57Z base=master head=codex/esql-input-oracle https://github.com/strawgate/memagent-e2e/pull/142
+#124 MERGED bench/kind: fix false degraded-source oracles and sink bottleneck in capacity probes (strawgate) updated=2026-04-09T18:28:53Z base=master head=codex/kind-bench-max-eps-fixes https://github.com/strawgate/memagent-e2e/pull/124
+#109 MERGED CI: artifact v5 migration + kind benchmark truthfulness gate (strawgate) updated=2026-04-09T14:12:20Z base=master head=codex/bench-workflow-truthfulness-v5 https://github.com/strawgate/memagent-e2e/pull/109
+#94 MERGED Compose bench: add filebeat, strict integrity checks, and report cleanup (strawgate) updated=2026-04-09T04:19:18Z base=master head=codex/bench-filebeat-integrity https://github.com/strawgate/memagent-e2e/pull/94
+#91 MERGED Compose bench: ingest matrix, monitor merge, strict summary gate (strawgate) updated=2026-04-08T19:41:35Z base=master head=codex/bench-compose-metrics-fixes https://github.com/strawgate/memagent-e2e/pull/91
+#85 MERGED Add non-KIND compose benchmark harness (strawgate) updated=2026-04-08T17:01:38Z base=master head=codex/bench-compose-smoke https://github.com/strawgate/memagent-e2e/pull/85
+#82 MERGED Bench: add sink CPU/RSS diagnostics to KIND benchmark results (strawgate) updated=2026-04-09T04:21:04Z base=master head=codex/bench-sink-metrics https://github.com/strawgate/memagent-e2e/pull/82
+#38 [DRAFT] CLOSED Bench: rebalance high-EPS CPU budget toward sink (strawgate) updated=2026-04-09T18:59:43Z base=master head=codex/eps-target-sweep https://github.com/strawgate/memagent-e2e/pull/38
+#14 MERGED Add target EPS ladder and max-throughput benchmark mode (strawgate) updated=2026-04-07T20:16:09Z base=master head=codex/eps-target-sweep https://github.com/strawgate/memagent-e2e/pull/14
+#12 MERGED Add nightly EPS benchmark suite summary and reporting (strawgate) updated=2026-04-07T14:31:49Z base=master head=codex/nightly-eps-report https://github.com/strawgate/memagent-e2e/pull/12
+#11 MERGED Fix bench aggregate duplicate auth header failures (strawgate) updated=2026-04-07T13:29:06Z base=master head=codex/bench-aggregate-auth-header https://github.com/strawgate/memagent-e2e/pull/11
+#10 MERGED Fix memcached nightly failure by ensuring log mount write access (strawgate) updated=2026-04-07T13:12:47Z base=master head=codex/e2e-memcached-log-permission https://github.com/strawgate/memagent-e2e/pull/10
+#9 MERGED Harden bench workflow against vector and stash race failures (strawgate) updated=2026-04-07T08:08:40Z base=master head=codex/bench-workflow-reliability https://github.com/strawgate/memagent-e2e/pull/9
+#8 MERGED Fix smoke suite memagent ref fallback to main (strawgate) updated=2026-04-07T07:46:01Z base=master head=codex/e2e-main-ref-fallback-cleanup https://github.com/strawgate/memagent-e2e/pull/8
+```
+
+### open issues (limit=30)
+
+```text
+#257 OPEN [PASS] Bench Compose Nightly EPS Report (all 96 passing) (app/github-actions) updated=2026-04-13T08:19:39Z https://github.com/strawgate/memagent-e2e/issues/257
+#256 OPEN [PASS] Bench Nightly EPS Report (6 non-gating, 42 passing) (app/github-actions) updated=2026-04-13T07:47:31Z https://github.com/strawgate/memagent-e2e/issues/256
+#255 OPEN [PASS] E2E Nightly Suite Report (all 9 passing) (app/github-actions) updated=2026-04-13T06:41:31Z https://github.com/strawgate/memagent-e2e/issues/255
+#252 OPEN [PASS] Bench Competitive Benchmarks Report (ladder_and_max) (10 non-gating, 70 passing) (app/github-actions) updated=2026-04-13T00:47:40Z https://github.com/strawgate/memagent-e2e/issues/252
+#251 OPEN [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-13T00:03:43Z https://github.com/strawgate/memagent-e2e/issues/251
+#244 OPEN bench: add file-backfill scenario (preseeded source) for max drain throughput (strawgate) updated=2026-04-11T20:54:53Z https://github.com/strawgate/memagent-e2e/issues/244
+#241 OPEN [PASS] Bench Compose Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T20:51:55Z https://github.com/strawgate/memagent-e2e/issues/241
+#237 OPEN bench/kind quick ladder: investigate dup_estimate spikes at 10k target (strawgate) updated=2026-04-11T20:38:53Z https://github.com/strawgate/memagent-e2e/issues/237
+#234 OPEN [PASS] Bench Compose Competitive Benchmarks Report (ladder_and_max) (all 6 passing) (app/github-actions) updated=2026-04-11T20:36:42Z https://github.com/strawgate/memagent-e2e/issues/234
+#227 OPEN [PASS] Bench Competitive Benchmarks Report (max) (all 1 passing) (app/github-actions) updated=2026-04-11T20:21:51Z https://github.com/strawgate/memagent-e2e/issues/227
+#226 OPEN [PASS] Bench Compose Competitive Benchmarks Report (max) (all 1 passing) (app/github-actions) updated=2026-04-11T20:19:45Z https://github.com/strawgate/memagent-e2e/issues/226
+#225 OPEN [PASS] Bench Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T20:13:43Z https://github.com/strawgate/memagent-e2e/issues/225
+#174 OPEN [FAIL] Bench Competitive Benchmarks Report (ladder) (1/7 failing) (app/github-actions) updated=2026-04-10T13:22:24Z https://github.com/strawgate/memagent-e2e/issues/174
+#167 OPEN [FAIL] Bench Competitive Benchmarks Report (2/80 failing) (app/github-actions) updated=2026-04-10T06:53:06Z https://github.com/strawgate/memagent-e2e/issues/167
+#166 OPEN [PASS] Bench Compose Competitive Benchmarks Report (all 96 passing) (app/github-actions) updated=2026-04-10T06:51:33Z https://github.com/strawgate/memagent-e2e/issues/166
+#74 OPEN Bench/kind: vlagent file lane has zero benchmark-tagged sink rows (strawgate) updated=2026-04-08T01:44:51Z https://github.com/strawgate/memagent-e2e/issues/74
+#73 OPEN Bench/kind: fluent-bit file lane misses one emitter source in smoke profile (strawgate) updated=2026-04-08T01:44:42Z https://github.com/strawgate/memagent-e2e/issues/73
+#13 OPEN Default benchmark profile can stall in kind harness under full source-oracle collection (strawgate) updated=2026-04-07T14:31:19Z https://github.com/strawgate/memagent-e2e/issues/13
+#4 OPEN bench: integrate KIND benchmark harness with octo11y/benchkit for throughput tracking (strawgate) updated=2026-04-06T07:51:12Z https://github.com/strawgate/memagent-e2e/issues/4
+#3 OPEN E2E Nightly Suite Report (app/github-actions) updated=2026-04-07T13:14:45Z https://github.com/strawgate/memagent-e2e/issues/3
+#1 OPEN E2E Smoke Suite Report (app/github-actions) updated=2026-04-07T17:33:06Z https://github.com/strawgate/memagent-e2e/issues/1
+```
+
+### recently closed issues (limit=30)
+
+```text
+#249 CLOSED [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-13T00:03:44Z https://github.com/strawgate/memagent-e2e/issues/249
+#247 CLOSED [PASS] Bench Compose Nightly EPS Report (all 96 passing) (app/github-actions) updated=2026-04-13T08:19:41Z https://github.com/strawgate/memagent-e2e/issues/247
+#246 CLOSED [FAIL] Bench Nightly EPS Report (6/48 failing) (app/github-actions) updated=2026-04-13T00:06:35Z https://github.com/strawgate/memagent-e2e/issues/246
+#245 CLOSED [PASS] E2E Nightly Suite Report (all 9 passing) (app/github-actions) updated=2026-04-13T06:41:32Z https://github.com/strawgate/memagent-e2e/issues/245
+#243 CLOSED [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-12T17:54:23Z https://github.com/strawgate/memagent-e2e/issues/243
+#240 CLOSED [PASS] Bench Compose Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T20:51:56Z https://github.com/strawgate/memagent-e2e/issues/240
+#239 CLOSED [PASS] E2E Nightly Suite Report (all 9 passing) (app/github-actions) updated=2026-04-12T06:37:04Z https://github.com/strawgate/memagent-e2e/issues/239
+#238 CLOSED [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-11T20:54:17Z https://github.com/strawgate/memagent-e2e/issues/238
+#236 CLOSED [PASS] Bench Competitive Benchmarks Report (ladder_and_max) (all 6 passing) (app/github-actions) updated=2026-04-13T00:47:41Z https://github.com/strawgate/memagent-e2e/issues/236
+#235 CLOSED [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-11T20:43:39Z https://github.com/strawgate/memagent-e2e/issues/235
+#233 CLOSED [PASS] Bench Competitive Benchmarks Report (ladder_and_max) (all 7 passing) (app/github-actions) updated=2026-04-11T20:38:01Z https://github.com/strawgate/memagent-e2e/issues/233
+#232 CLOSED [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-11T20:37:14Z https://github.com/strawgate/memagent-e2e/issues/232
+#231 CLOSED [PASS] Bench Compose Competitive Benchmarks Report (ladder_and_max) (all 7 passing) (app/github-actions) updated=2026-04-11T20:36:43Z https://github.com/strawgate/memagent-e2e/issues/231
+#230 CLOSED [FAIL] Bench Competitive Benchmarks Report (ladder_and_max) (1/8 failing) (app/github-actions) updated=2026-04-11T20:34:19Z https://github.com/strawgate/memagent-e2e/issues/230
+#229 CLOSED [FAIL] Bench Competitive Benchmarks Report (ladder_and_max) (1/8 failing) (app/github-actions) updated=2026-04-11T20:30:19Z https://github.com/strawgate/memagent-e2e/issues/229
+#228 CLOSED [PASS] Bench Compose Competitive Benchmarks Report (ladder_and_max) (all 8 passing) (app/github-actions) updated=2026-04-11T20:33:21Z https://github.com/strawgate/memagent-e2e/issues/228
+#224 CLOSED [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-11T20:33:21Z https://github.com/strawgate/memagent-e2e/issues/224
+#223 CLOSED [PASS] Bench Compose Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T20:50:26Z https://github.com/strawgate/memagent-e2e/issues/223
+#222 CLOSED [PASS] Bench Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T20:13:44Z https://github.com/strawgate/memagent-e2e/issues/222
+#221 CLOSED [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-11T20:13:11Z https://github.com/strawgate/memagent-e2e/issues/221
+#220 CLOSED [PASS] Bench Compose Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T20:12:20Z https://github.com/strawgate/memagent-e2e/issues/220
+#219 CLOSED [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-11T19:16:21Z https://github.com/strawgate/memagent-e2e/issues/219
+#218 CLOSED [FAIL] E2E Smoke Suite Report (2/5 failing) (app/github-actions) updated=2026-04-11T18:19:04Z https://github.com/strawgate/memagent-e2e/issues/218
+#217 CLOSED [PASS] Bench Competitive Benchmarks Report (profile) (all 2 passing) (app/github-actions) updated=2026-04-11T19:16:54Z https://github.com/strawgate/memagent-e2e/issues/217
+#216 CLOSED [FAIL] E2E Smoke Suite Report (4/5 failing) (app/github-actions) updated=2026-04-11T18:15:37Z https://github.com/strawgate/memagent-e2e/issues/216
+#215 CLOSED [PASS] Bench Compose Competitive Benchmarks Report (profile) (all 2 passing) (app/github-actions) updated=2026-04-11T19:15:51Z https://github.com/strawgate/memagent-e2e/issues/215
+#214 CLOSED [PASS] Bench Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T18:14:12Z https://github.com/strawgate/memagent-e2e/issues/214
+#213 CLOSED [FAIL] E2E Smoke Suite Report (4/5 failing) (app/github-actions) updated=2026-04-11T18:13:55Z https://github.com/strawgate/memagent-e2e/issues/213
+#212 CLOSED [PASS] Bench Compose Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T18:12:36Z https://github.com/strawgate/memagent-e2e/issues/212
+#211 CLOSED [FAIL] Bench Competitive Benchmarks Report (profile) (1/1 failing) (app/github-actions) updated=2026-04-11T18:09:59Z https://github.com/strawgate/memagent-e2e/issues/211
+```
+
+## Current Directory Files
+
+### directory tree from cwd (depth=3, max=500)
+
+```text
+.codex
+.codex/refresh
+.codex/refresh/refresh-20260414-051616.md
+.git
+.github
+.github/actions
+.github/actions/checkout-memagent
+.github/actions/collect-e2e-artifacts
+.github/actions/publish-e2e-summary
+.github/actions/setup-compose
+.github/actions/setup-kind
+.github/actions/setup-memagent-build
+.github/workflows
+.github/workflows/_scenario-compose.yml
+.github/workflows/_scenario-kind.yml
+.github/workflows/_scenario-otlp.yml
+.github/workflows/bench-compose-smoke.yml
+.github/workflows/bench-kind-aggregate.yml
+.github/workflows/bench-kind-smoke.yml
+.github/workflows/docs.yml
+.github/workflows/e2e-compose-esql-input-oracle.yml
+.github/workflows/e2e-compose-memcached.yml
+.github/workflows/e2e-compose-nginx.yml
+.github/workflows/e2e-compose-redis.yml
+.github/workflows/e2e-compose-synthetic-burst.yml
+.github/workflows/e2e-compose-synthetic-multiline.yml
+.github/workflows/e2e-compose-synthetic-rotation.yml
+.github/workflows/e2e-kind-cri-smoke.yml
+.github/workflows/e2e-nightly.yml
+.github/workflows/e2e-otlp-input-oracle.yml
+.github/workflows/e2e-otlp-output-oracle.yml
+.github/workflows/e2e-smoke.yml
+.gitignore
+.pytest_cache
+.pytest_cache/.gitignore
+.pytest_cache/CACHEDIR.TAG
+.pytest_cache/README.md
+.pytest_cache/v
+.pytest_cache/v/cache
+README.md
+bench
+bench/compose
+bench/compose/README.md
+bench/compose/run.py
+bench/kind
+bench/kind/README.md
+bench/kind/RESULT_SCHEMA.md
+bench/kind/__pycache__
+bench/kind/lib
+bench/kind/manifests
+bench/kind/render_issue_summary.py
+bench/kind/run.py
+bench/kind/tests
+bench/lib
+bench/lib/write_missing_result.py
+docs
+docs/SCENARIO_PLATFORM.md
+docs/index.md
+mkdocs.yml
+reporting
+reporting/__init__.py
+reporting/__pycache__
+reporting/__pycache__/__init__.cpython-311.pyc
+reporting/__pycache__/markdown.cpython-311.pyc
+reporting/markdown.py
+tests
+tests/e2e
+tests/e2e/README.md
+tests/e2e/lib
+tests/e2e/run-scenario.sh
+tests/e2e/scenarios
+```
+
+### tracked files in repo (max=500)
+
+```text
+.github/actions/checkout-memagent/action.yml
+.github/actions/collect-e2e-artifacts/action.yml
+.github/actions/publish-e2e-summary/action.yml
+.github/actions/setup-compose/action.yml
+.github/actions/setup-kind/action.yml
+.github/actions/setup-memagent-build/action.yml
+.github/workflows/_scenario-compose.yml
+.github/workflows/_scenario-kind.yml
+.github/workflows/_scenario-otlp.yml
+.github/workflows/bench-compose-smoke.yml
+.github/workflows/bench-kind-aggregate.yml
+.github/workflows/bench-kind-smoke.yml
+.github/workflows/docs.yml
+.github/workflows/e2e-compose-esql-input-oracle.yml
+.github/workflows/e2e-compose-memcached.yml
+.github/workflows/e2e-compose-nginx.yml
+.github/workflows/e2e-compose-redis.yml
+.github/workflows/e2e-compose-synthetic-burst.yml
+.github/workflows/e2e-compose-synthetic-multiline.yml
+.github/workflows/e2e-compose-synthetic-rotation.yml
+.github/workflows/e2e-kind-cri-smoke.yml
+.github/workflows/e2e-nightly.yml
+.github/workflows/e2e-otlp-input-oracle.yml
+.github/workflows/e2e-otlp-output-oracle.yml
+.github/workflows/e2e-smoke.yml
+.gitignore
+README.md
+bench/compose/README.md
+bench/compose/run.py
+bench/kind/README.md
+bench/kind/RESULT_SCHEMA.md
+bench/kind/lib/analyze.py
+bench/kind/lib/cluster.py
+bench/kind/lib/collectors.py
+bench/kind/lib/diagnostics.py
+bench/kind/lib/kube.py
+bench/kind/lib/measure.py
+bench/kind/lib/profiles.py
+bench/kind/lib/results.py
+bench/kind/manifests/collectors/logfwd-configmap.yaml.tmpl
+bench/kind/manifests/collectors/logfwd-daemonset.yaml.tmpl
+bench/kind/manifests/collectors/logfwd-otlp-configmap.yaml.tmpl
+bench/kind/manifests/collectors/logfwd-otlp-daemonset.yaml.tmpl
+bench/kind/manifests/collectors/otelcol-configmap.yaml.tmpl
+bench/kind/manifests/collectors/otelcol-daemonset.yaml.tmpl
+bench/kind/manifests/collectors/otelcol-otlp-configmap.yaml.tmpl
+bench/kind/manifests/collectors/otelcol-otlp-daemonset.yaml.tmpl
+bench/kind/manifests/collectors/vector-configmap.yaml.tmpl
+bench/kind/manifests/collectors/vector-daemonset.yaml.tmpl
+bench/kind/manifests/common/namespace.yaml
+bench/kind/manifests/common/sink-configmap.yaml.tmpl
+bench/kind/manifests/common/sink-deployment.yaml.tmpl
+bench/kind/manifests/workload/log-emitter-configmap-otlp.yaml.tmpl
+bench/kind/manifests/workload/log-emitter-configmap.yaml.tmpl
+bench/kind/manifests/workload/log-emitter-statefulset.yaml.tmpl
+bench/kind/render_issue_summary.py
+bench/kind/run.py
+bench/kind/tests/test_diagnostics.py
+bench/lib/write_missing_result.py
+docs/SCENARIO_PLATFORM.md
+docs/index.md
+mkdocs.yml
+reporting/__init__.py
+reporting/markdown.py
+tests/e2e/README.md
+tests/e2e/lib/capture_tcp.py
+tests/e2e/lib/check_scenarios.py
+tests/e2e/lib/common.sh
+tests/e2e/lib/oracle.py
+tests/e2e/lib/otlp_oracle.sh
+tests/e2e/lib/render_issue_summary.py
+tests/e2e/lib/source_evidence.py
+tests/e2e/lib/upsert_issue.sh
+tests/e2e/run-scenario.sh
+tests/e2e/scenarios/compose-esql-input-oracle/compose.yaml
+tests/e2e/scenarios/compose-esql-input-oracle/memagent.yaml
+tests/e2e/scenarios/compose-esql-input-oracle/oracle.json
+tests/e2e/scenarios/compose-esql-input-oracle/run_workload.sh
+tests/e2e/scenarios/compose-esql-input-oracle/up.sh
+tests/e2e/scenarios/compose-memcached/compose.yaml
+tests/e2e/scenarios/compose-memcached/memagent.yaml
+tests/e2e/scenarios/compose-memcached/oracle.json
+tests/e2e/scenarios/compose-memcached/run_workload.sh
+tests/e2e/scenarios/compose-memcached/up.sh
+tests/e2e/scenarios/compose-nginx/compose.yaml
+tests/e2e/scenarios/compose-nginx/memagent.yaml
+tests/e2e/scenarios/compose-nginx/nginx.conf
+tests/e2e/scenarios/compose-nginx/oracle.json
+tests/e2e/scenarios/compose-nginx/run_workload.sh
+tests/e2e/scenarios/compose-redis/compose.yaml
+tests/e2e/scenarios/compose-redis/memagent.yaml
+tests/e2e/scenarios/compose-redis/oracle.json
+tests/e2e/scenarios/compose-redis/run_workload.sh
+tests/e2e/scenarios/compose-synthetic-burst/compose.yaml
+tests/e2e/scenarios/compose-synthetic-burst/memagent.yaml
+tests/e2e/scenarios/compose-synthetic-burst/oracle.json
+tests/e2e/scenarios/compose-synthetic-burst/run_workload.sh
+tests/e2e/scenarios/compose-synthetic-multiline/compose.yaml
+tests/e2e/scenarios/compose-synthetic-multiline/memagent.yaml
+tests/e2e/scenarios/compose-synthetic-multiline/oracle.json
+tests/e2e/scenarios/compose-synthetic-multiline/run_workload.sh
+tests/e2e/scenarios/compose-synthetic-rotation/compose.yaml
+tests/e2e/scenarios/compose-synthetic-rotation/memagent.yaml
+tests/e2e/scenarios/compose-synthetic-rotation/oracle.json
+tests/e2e/scenarios/compose-synthetic-rotation/run_workload.sh
+tests/e2e/scenarios/kind-cri-smoke/collect.sh
+tests/e2e/scenarios/kind-cri-smoke/down.sh
+tests/e2e/scenarios/kind-cri-smoke/manifests/capture-receiver.yaml
+tests/e2e/scenarios/kind-cri-smoke/manifests/log-generator.yaml
+tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-config.yaml
+tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-daemonset.yaml
+tests/e2e/scenarios/kind-cri-smoke/oracle.json
+tests/e2e/scenarios/kind-cri-smoke/run_workload.sh
+tests/e2e/scenarios/kind-cri-smoke/up.sh
+tests/e2e/scenarios/kind-cri-smoke/verify.sh
+tests/e2e/scenarios/otlp-input-oracle/run_workload.sh
+tests/e2e/scenarios/otlp-input-oracle/verify.sh
+tests/e2e/scenarios/otlp-output-oracle/run_workload.sh
+tests/e2e/scenarios/otlp-output-oracle/verify.sh
+```
+
+## Suggested Follow-Up
+
+1. Read this snapshot from top to bottom and list assumptions that might now be stale (architecture, contracts, release process, dependencies, roadmap).
+2. Inspect likely-changing files from recent main commits first (design docs, crate contracts, runtime wiring, CI, Cargo.toml).
+3. Cross-check open PRs/issues for behavior changes that have not landed on main yet but affect near-term work.
+4. Produce a short 'what changed / what did not change / what needs deeper confirmation' memo before coding.
+

--- a/.github/workflows/bench-kind-smoke.yml
+++ b/.github/workflows/bench-kind-smoke.yml
@@ -99,7 +99,7 @@ jobs:
       target_set: ${{ steps.plan.outputs.target_set }}
       collectors: ${{ steps.plan.outputs.collectors }}
       cpu_profiles: ${{ steps.plan.outputs.cpu_profiles }}
-      ingest_modes: ${{ steps.plan.outputs.ingest_modes }}
+      ingest_configs: ${{ steps.plan.outputs.ingest_configs }}
       workloads: ${{ steps.plan.outputs.workloads }}
     steps:
       - id: plan
@@ -163,14 +163,18 @@ jobs:
           else
             echo 'cpu_profiles=["single","multi"]' >>"$GITHUB_OUTPUT"
           fi
+          OTLP_CONFIGS='[{"mode":"otlp","label":"otlp-100k","batch_bytes":"102400"},{"mode":"otlp","label":"otlp-4m","batch_bytes":"4194304"}]'
+          FILE_CONFIG='[{"mode":"file","label":"file","batch_bytes":""}]'
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ "${INPUT_INGEST_MODE}" != "all" ]]; then
-              echo "ingest_modes=[\"${INPUT_INGEST_MODE}\"]" >>"$GITHUB_OUTPUT"
+            if [[ "${INPUT_INGEST_MODE}" == "file" ]]; then
+              echo "ingest_configs=${FILE_CONFIG}" >>"$GITHUB_OUTPUT"
+            elif [[ "${INPUT_INGEST_MODE}" == "otlp" ]]; then
+              echo "ingest_configs=${OTLP_CONFIGS}" >>"$GITHUB_OUTPUT"
             else
-              echo 'ingest_modes=["file","otlp"]' >>"$GITHUB_OUTPUT"
+              echo "ingest_configs=$(echo "${FILE_CONFIG}${OTLP_CONFIGS}" | python3 -c 'import sys,json; a,b=sys.stdin.read().split("]["); print(json.dumps(json.loads(a+"]")+json.loads("["+b)))')" >>"$GITHUB_OUTPUT"
             fi
           else
-            echo 'ingest_modes=["file"]' >>"$GITHUB_OUTPUT"
+            echo "ingest_configs=${FILE_CONFIG}" >>"$GITHUB_OUTPUT"
           fi
 
   kind-bench-smoke:
@@ -181,26 +185,30 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix:
-        ingest_mode: ${{ fromJSON(needs.plan.outputs.ingest_modes) }}
+        ingest_config: ${{ fromJSON(needs.plan.outputs.ingest_configs) }}
         collector: ${{ fromJSON(needs.plan.outputs.collectors) }}
         cpu_profile: ${{ fromJSON(needs.plan.outputs.cpu_profiles) }}
         workload: ${{ fromJSON(needs.plan.outputs.workloads) }}
         exclude:
-          - ingest_mode: otlp
+          - ingest_config: {"mode":"otlp","label":"otlp-100k","batch_bytes":"102400"}
+            collector: vector
+          - ingest_config: {"mode":"otlp","label":"otlp-4m","batch_bytes":"4194304"}
             collector: vector
     env:
       MEMAGENT_REPO_ROOT: ${{ github.workspace }}/memagent
       BENCH_PROFILE: ${{ needs.plan.outputs.bench_profile }}
-      BENCH_RESULTS_DIR: ${{ github.workspace }}/bench/kind/results/${{ needs.plan.outputs.bench_profile }}/${{ matrix.ingest_mode }}/${{ matrix.workload.label }}/${{ matrix.cpu_profile }}/${{ matrix.collector }}
-      CLUSTER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.ingest_mode }}-${{ matrix.cpu_profile }}-${{ matrix.collector }}-${{ matrix.workload.label }}
+      BENCH_RESULTS_DIR: ${{ github.workspace }}/bench/kind/results/${{ needs.plan.outputs.bench_profile }}/${{ matrix.ingest_config.label }}/${{ matrix.workload.label }}/${{ matrix.cpu_profile }}/${{ matrix.collector }}
+      CLUSTER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.ingest_config.label }}-${{ matrix.cpu_profile }}-${{ matrix.collector }}-${{ matrix.workload.label }}
       BENCH_COLLECTOR: ${{ matrix.collector }}
-      BENCH_INGEST_MODE: ${{ matrix.ingest_mode }}
+      BENCH_INGEST_MODE: ${{ matrix.ingest_config.mode }}
+      BENCH_INGEST_LABEL: ${{ matrix.ingest_config.label }}
+      BENCH_EMITTER_BATCH_TARGET_BYTES: ${{ matrix.ingest_config.batch_bytes }}
       BENCH_CPU_PROFILE: ${{ matrix.cpu_profile }}
       BENCH_WORKLOAD_LABEL: ${{ matrix.workload.label }}
       BENCH_PODS: ${{ matrix.workload.pods }}
       BENCH_EPS_PER_POD: ${{ matrix.workload.eps_per_pod }}
       BENCH_COLLECTOR_BATCH_TARGET_BYTES: ${{ inputs.collector_batch_target_bytes || '' }}
-      BENCHKIT_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}--kind-bench-${{ needs.plan.outputs.bench_profile }}-${{ matrix.ingest_mode }}-${{ matrix.workload.label }}-${{ matrix.cpu_profile }}-${{ matrix.collector }}
+      BENCHKIT_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}--kind-bench-${{ needs.plan.outputs.bench_profile }}-${{ matrix.ingest_config.label }}-${{ matrix.workload.label }}-${{ matrix.cpu_profile }}-${{ matrix.collector }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -242,6 +250,8 @@ jobs:
             --eps-per-pod "${BENCH_EPS_PER_POD}" \
             --collector "${BENCH_COLLECTOR}" \
             --ingest-mode "${BENCH_INGEST_MODE}" \
+            --ingest-label "${BENCH_INGEST_LABEL}" \
+            --emitter-batch-target-bytes "${BENCH_EMITTER_BATCH_TARGET_BYTES}" \
             --cpu-profile "${BENCH_CPU_PROFILE}" \
             --protocol otlp_http \
             --cluster-name "${CLUSTER_NAME}" \
@@ -268,6 +278,7 @@ jobs:
             --namespace "memagent-bench" \
             --collector "${BENCH_COLLECTOR}" \
             --ingest-mode "${BENCH_INGEST_MODE}" \
+            --ingest-label "${BENCH_INGEST_LABEL}" \
             --cpu-profile "${BENCH_CPU_PROFILE}" \
             --pods "${BENCH_PODS}" \
             --target-eps-per-pod "${BENCH_EPS_PER_POD}" \
@@ -298,7 +309,7 @@ jobs:
       - if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: kind-bench-${{ needs.plan.outputs.bench_profile }}-${{ matrix.ingest_mode }}-${{ matrix.workload.label }}-${{ matrix.cpu_profile }}-${{ matrix.collector }}
+          name: kind-bench-${{ needs.plan.outputs.bench_profile }}-${{ matrix.ingest_config.label }}-${{ matrix.workload.label }}-${{ matrix.cpu_profile }}-${{ matrix.collector }}
           path: ${{ env.BENCH_RESULTS_DIR }}
           retention-days: 7
 
@@ -374,7 +385,7 @@ jobs:
         env:
           EXPECTED_COLLECTORS: ${{ needs.plan.outputs.collectors }}
           EXPECTED_CPU_PROFILES: ${{ needs.plan.outputs.cpu_profiles }}
-          EXPECTED_INGEST_MODES: ${{ needs.plan.outputs.ingest_modes }}
+          EXPECTED_INGEST_CONFIGS: ${{ needs.plan.outputs.ingest_configs }}
           EXPECTED_WORKLOADS: ${{ needs.plan.outputs.workloads }}
           NON_GATING_COLLECTORS: '["vector"]'
           NON_GATING_EPS_MIN: "10000"
@@ -396,12 +407,13 @@ jobs:
 
           collectors = json.loads(os.environ["EXPECTED_COLLECTORS"])
           cpu_profiles = json.loads(os.environ["EXPECTED_CPU_PROFILES"])
-          ingest_modes = json.loads(os.environ["EXPECTED_INGEST_MODES"])
+          ingest_configs = json.loads(os.environ["EXPECTED_INGEST_CONFIGS"])
           workloads = json.loads(os.environ["EXPECTED_WORKLOADS"])
 
-          expected = len(collectors) * len(cpu_profiles) * len(ingest_modes) * len(workloads)
-          if "vector" in collectors and "otlp" in ingest_modes:
-            expected -= len(cpu_profiles) * len(workloads)
+          expected = len(collectors) * len(cpu_profiles) * len(ingest_configs) * len(workloads)
+          otlp_configs = [c for c in ingest_configs if c["mode"] == "otlp"]
+          if "vector" in collectors and otlp_configs:
+            expected -= len(cpu_profiles) * len(workloads) * len(otlp_configs)
 
           print(
             f"expected={expected} benchmark_count={benchmark_count} failed_count={failed_count}"

--- a/bench/kind/manifests/workload/log-emitter-configmap-otlp.yaml.tmpl
+++ b/bench/kind/manifests/workload/log-emitter-configmap-otlp.yaml.tmpl
@@ -46,4 +46,4 @@ data:
     output:
       type: otlp
       endpoint: http://bench-collector.${NAMESPACE}.svc.cluster.local:4318/v1/logs
-      batch_target_bytes: 4194304
+      ${EMITTER_BATCH_TARGET_BYTES_YAML}

--- a/bench/kind/render_issue_summary.py
+++ b/bench/kind/render_issue_summary.py
@@ -198,7 +198,7 @@ def cpu_rank(name: str) -> tuple[int, str]:
 
 
 def ingest_rank(name: str) -> tuple[int, str]:
-    order = {"file": 0, "otlp": 1}
+    order = {"file": 0, "otlp": 1, "otlp-100k": 1, "otlp-4m": 2}
     return (order.get(name, 99), name)
 
 

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -142,6 +142,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--profile", choices=sorted(PROFILES), default="smoke")
     parser.add_argument("--collector", default="logfwd")
     parser.add_argument("--ingest-mode", choices=["file", "otlp"], default="file")
+    parser.add_argument("--ingest-label", type=lambda v: v or None, default=None, help="Label stored in result.json for ingest config (defaults to --ingest-mode)")
+    parser.add_argument(
+        "--emitter-batch-target-bytes",
+        type=lambda v: int(v) if v else None,
+        default=None,
+        help="Target batch size in bytes for OTLP emitter output. Sets EMITTER_BATCH_TARGET_BYTES_YAML in manifests.",
+    )
     parser.add_argument("--protocol", default="otlp_http")
     parser.add_argument("--cluster-name", default="memagent-bench")
     parser.add_argument("--namespace", default="memagent-bench")
@@ -713,6 +720,10 @@ def render_manifests(
     if collector_batch_target_bytes is not None:
         collector_batch_target_yaml = f"        batch_target_bytes: {collector_batch_target_bytes}"
 
+    emitter_batch_target_yaml = ""
+    if args.emitter_batch_target_bytes is not None:
+        emitter_batch_target_yaml = f"        batch_target_bytes: {args.emitter_batch_target_bytes}"
+
     substitutions = {
         "NAMESPACE": args.namespace,
         "MEMAGENT_IMAGE": args.memagent_image,
@@ -738,6 +749,7 @@ def render_manifests(
         "CAPTURE_READER_MEMORY_REQUEST": resource_plan.capture_reader_memory,
         "CAPTURE_READER_MEMORY_LIMIT": resource_plan.capture_reader_memory,
         "COLLECTOR_BATCH_TARGET_BYTES_YAML": collector_batch_target_yaml,
+        "EMITTER_BATCH_TARGET_BYTES_YAML": emitter_batch_target_yaml,
     }
     manifests = {
         "namespace": rendered_dir / "namespace.yaml",
@@ -1336,7 +1348,7 @@ def main() -> int:
         namespace=args.namespace,
         collector=args.collector,
         protocol=adapter.sink_transport if args.protocol == "otlp_http" else args.protocol,
-        ingest_mode=args.ingest_mode,
+        ingest_mode=args.ingest_label or args.ingest_mode,
         cpu_profile=args.cpu_profile,
         cluster_cpu_limit_cores=resource_plan.cluster_cpu_cores,
         collector_batch_target_bytes=collector_batch_target_bytes,

--- a/bench/lib/write_missing_result.py
+++ b/bench/lib/write_missing_result.py
@@ -23,6 +23,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--namespace", required=True)
     parser.add_argument("--collector", required=True)
     parser.add_argument("--ingest-mode", required=True)
+    parser.add_argument("--ingest-label", default=None, help="Label stored in result.json for ingest config (defaults to --ingest-mode)")
     parser.add_argument("--cpu-profile", required=True)
     parser.add_argument("--pods", type=int, required=True)
     parser.add_argument("--target-eps-per-pod", type=int, required=True)
@@ -63,7 +64,7 @@ def main() -> None:
             "namespace": args.namespace,
             "collector": args.collector,
             "protocol": infer_protocol(cluster=args.cluster, collector=args.collector),
-            "ingest_mode": args.ingest_mode,
+            "ingest_mode": args.ingest_label or args.ingest_mode,
             "cpu_profile": args.cpu_profile,
             "cluster_cpu_limit_cores": None,
             "collector_batch_target_bytes": args.collector_batch_target_bytes,


### PR DESCRIPTION
## Summary

Adds a small/large batch-size dimension to OTLP ingest lanes in the kind benchmark matrix so we can measure competitive fairness: logfwd benefits from large batches but otelcol and other collectors may perform better with many small batches.

### Changes

- **bench-kind-smoke.yml**: replaces `ingest_modes` (string array) with `ingest_configs` (object array `{mode, label, batch_bytes}`). File stays as one entry; OTLP expands to two:
  - `otlp-100k` — 102400 B emitter batch (realistic small)
  - `otlp-4m` — 4194304 B emitter batch (high-throughput large)
- **run.py**: adds `--ingest-label` (stored in result.json) and `--emitter-batch-target-bytes` (controls `EMITTER_BATCH_TARGET_BYTES_YAML` manifest substitution); both handle empty-string gracefully for file mode
- **log-emitter-configmap-otlp.yaml.tmpl**: replaces hardcoded `batch_target_bytes: 4194304` with `${EMITTER_BATCH_TARGET_BYTES_YAML}`
- **render_issue_summary.py**: extends `ingest_rank()` to handle `otlp-100k` (rank 1) and `otlp-4m` (rank 2)
- **write_missing_result.py**: adds `--ingest-label` passthrough for fallback result rows

### Expected count change

Schedule (file only): unchanged (1 file config × 2 cpu × N workloads × 3 collectors).
Dispatch with `ingest_mode=all`: was 2 modes, now 3 configs (file + 2× OTLP). Vector still excluded from both OTLP configs.

### Test plan

After merge, run:
```
gh workflow run 'Bench / kind smoke' --ref main -f collector=logfwd -f target_set=ladder_and_max -f ingest_mode=otlp
```
Expect separate result rows for `otlp-100k` and `otlp-4m` in the report.