### PR TITLE
feat: add max_file_size_bytes to file-ingest generator config

### DIFF
--- a/bench/compose/run.py
+++ b/bench/compose/run.py
@@ -327,6 +327,7 @@ output:
   type: file
   path: /runtime/events.ndjson
   format: json
+  max_file_size_bytes: 209715200
 """
         )
     return (


### PR DESCRIPTION
## Summary

Adds `max_file_size_bytes: 209715200` (200MB) to the file-ingest generator config so the generator doesn't spin at 100% CPU producing data faster than any collector reads.

### Problem

The file-ingest generator uses ~1.0 CPU regardless of actual EPS throughput (see #293). The generator writes to a file with no backpressure, spinning indefinitely.

### Solution

Uses the new `max_file_size_bytes` config option from strawgate/memagent#2239 to cap the generator's output file at 200MB. Once the file exceeds this size, the file sink yields 10ms per batch, creating pipeline backpressure that throttles the generator to near-zero CPU.

### Dependencies

- Requires strawgate/memagent#2239 (the logfwd feature)

Closes #293