### PR TITLE
fix: cap file-ingest EPS, raise emitter CPU, rename nightly reports

### DIFF
--- a/.codex/refresh/refresh-20260416-054122.md
+++ b/.codex/refresh/refresh-20260416-054122.md
@@ -1,0 +1,426 @@
+# Refresh Snapshot
+
+- Generated (UTC): 2026-04-16T05:41:22Z
+- Repo root: /home/bill_easton/memagent-e2e
+- Current cwd: /home/bill_easton/memagent-e2e
+- Repo: strawgate/memagent-e2e
+- Default branch: main
+- Repo URL: https://github.com/strawgate/memagent-e2e
+
+## Working Tree
+
+### git status -sb
+
+```text
+## main...origin/main
+?? .codex/refresh/refresh-20260416-054122.md
+```
+
+### current branch
+
+```text
+main
+```
+
+### HEAD
+
+```text
+3c042bc5b6544fb8f7d4a79f8abad007f67b8aeb
+```
+
+## Recent Commits
+
+### current branch commits (latest 20)
+
+```text
+3c042bc5 2026-04-16 GitHub Copilot fix: move emitter OTLP config to pipelines form; fix batch_target_bytes placement
+0e917cef 2026-04-16 GitHub Copilot fix: correct EMITTER_BATCH_TARGET_BYTES_YAML indentation in substitution
+35fb1fe5 2026-04-15 Bill Easton feat: add OTLP batch-size matrix (100kb / 4mb) to kind benchmark (#280)
+0ec4c7e6 2026-04-15 Bill Easton fix(bench): cap OTLP emitter batch to 4MB, revert 100MB collector limit (#279)
+c4024bc3 2026-04-15 Bill Easton fix(bench): raise OTLP collector max_request_body_size to 100MB (#278)
+3b5a7997 2026-04-14 Bill Easton feat(bench): collect collector CPU flamegraph as bench artifact (#269)
+64b70370 2026-04-14 Bill Easton feat(report): pretty-print EPS as k, add memory columns, fix snapshot table (#268)
+c47e654b 2026-04-14 GitHub Copilot fix: use 3-core budget for multi capacity-probe lanes on 2-core runners
+4b3bf723 2026-04-14 GitHub Copilot fix: remove drain-window artifact note from reports
+9104345a 2026-04-14 Bill Easton fix: accept float seq values in filter_rows_to_emitter_snapshot (#265)
+0f895a8e 2026-04-14 Bill Easton fix: raise emitter rollout timeout floor 120s → 300s (#260)
+656af5ae 2026-04-14 Bill Easton bench(kind): fix collector CPU to exactly 1/2 cores and shorten otelcol drain (#258)
+56268a94 2026-04-12 Bill Easton docs: add drain-window artifact note to Integrity Alerts section (#254)
+dcb182ed 2026-04-12 Bill Easton fix: show n/a for vector collector CPU when process metrics are unavailable (#253)
+7e45231b 2026-04-12 Bill Easton fix: stabilize kind nightly EPS for saturation-target lanes (#250)
+466047a9 2026-04-12 strawgate docs: point mkdocs edit links to main
+d57950ef 2026-04-12 Bill Easton docs: enable GitHub Pages publishing
+a5d254b2 2026-04-11 Bill Easton bench/e2e: stabilize nightly main and fill compose sink CPU (#242)
+beda1aa8 2026-04-11 Bill Easton bench/e2e cleanup: dedupe workflows, tighten scenario defaults, prune stale assets (#197)
+bdfb0c69 2026-04-10 Bill Easton bench(kind): increase shared OTLP max collector memory to 4Gi (#184)```
+
+### origin/main commits (latest 20)
+
+```text
+3c042bc5 2026-04-16 GitHub Copilot fix: move emitter OTLP config to pipelines form; fix batch_target_bytes placement
+0e917cef 2026-04-16 GitHub Copilot fix: correct EMITTER_BATCH_TARGET_BYTES_YAML indentation in substitution
+35fb1fe5 2026-04-15 Bill Easton feat: add OTLP batch-size matrix (100kb / 4mb) to kind benchmark (#280)
+0ec4c7e6 2026-04-15 Bill Easton fix(bench): cap OTLP emitter batch to 4MB, revert 100MB collector limit (#279)
+c4024bc3 2026-04-15 Bill Easton fix(bench): raise OTLP collector max_request_body_size to 100MB (#278)
+3b5a7997 2026-04-14 Bill Easton feat(bench): collect collector CPU flamegraph as bench artifact (#269)
+64b70370 2026-04-14 Bill Easton feat(report): pretty-print EPS as k, add memory columns, fix snapshot table (#268)
+c47e654b 2026-04-14 GitHub Copilot fix: use 3-core budget for multi capacity-probe lanes on 2-core runners
+4b3bf723 2026-04-14 GitHub Copilot fix: remove drain-window artifact note from reports
+9104345a 2026-04-14 Bill Easton fix: accept float seq values in filter_rows_to_emitter_snapshot (#265)
+0f895a8e 2026-04-14 Bill Easton fix: raise emitter rollout timeout floor 120s → 300s (#260)
+656af5ae 2026-04-14 Bill Easton bench(kind): fix collector CPU to exactly 1/2 cores and shorten otelcol drain (#258)
+56268a94 2026-04-12 Bill Easton docs: add drain-window artifact note to Integrity Alerts section (#254)
+dcb182ed 2026-04-12 Bill Easton fix: show n/a for vector collector CPU when process metrics are unavailable (#253)
+7e45231b 2026-04-12 Bill Easton fix: stabilize kind nightly EPS for saturation-target lanes (#250)
+466047a9 2026-04-12 strawgate docs: point mkdocs edit links to main
+d57950ef 2026-04-12 Bill Easton docs: enable GitHub Pages publishing
+a5d254b2 2026-04-11 Bill Easton bench/e2e: stabilize nightly main and fill compose sink CPU (#242)
+beda1aa8 2026-04-11 Bill Easton bench/e2e cleanup: dedupe workflows, tighten scenario defaults, prune stale assets (#197)
+bdfb0c69 2026-04-10 Bill Easton bench(kind): increase shared OTLP max collector memory to 4Gi (#184)```
+
+### files changed on origin/main across last 20 commits
+
+```text
+A	.codex/refresh/refresh-20260414-051616.md
+A	.github/actions/checkout-memagent/action.yml
+M	.github/actions/setup-memagent-build/action.yml
+M	.github/workflows/_scenario-compose.yml
+M	.github/workflows/_scenario-kind.yml
+M	.github/workflows/_scenario-otlp.yml
+M	.github/workflows/bench-compose-smoke.yml
+M	.github/workflows/bench-kind-aggregate.yml
+M	.github/workflows/bench-kind-smoke.yml
+A	.github/workflows/docs.yml
+M	.github/workflows/e2e-nightly.yml
+M	.github/workflows/e2e-smoke.yml
+M	README.md
+M	bench/compose/README.md
+M	bench/compose/run.py
+M	bench/kind/README.md
+M	bench/kind/RESULT_SCHEMA.md
+A	bench/kind/lib/diagnostics.py
+M	bench/kind/lib/kube.py
+M	bench/kind/lib/measure.py
+M	bench/kind/lib/profiles.py
+M	bench/kind/lib/results.py
+M	bench/kind/manifests/collectors/logfwd-configmap.yaml.tmpl
+M	bench/kind/manifests/collectors/logfwd-daemonset.yaml.tmpl
+M	bench/kind/manifests/collectors/logfwd-otlp-configmap.yaml.tmpl
+M	bench/kind/manifests/collectors/logfwd-otlp-daemonset.yaml.tmpl
+M	bench/kind/manifests/collectors/otelcol-configmap.yaml.tmpl
+M	bench/kind/manifests/collectors/otelcol-otlp-configmap.yaml.tmpl
+M	bench/kind/manifests/common/sink-deployment.yaml.tmpl
+M	bench/kind/manifests/workload/log-emitter-configmap-otlp.yaml.tmpl
+M	bench/kind/manifests/workload/log-emitter-statefulset.yaml.tmpl
+M	bench/kind/render_issue_summary.py
+M	bench/kind/run.py
+A	bench/kind/tests/test_diagnostics.py
+A	bench/lib/write_missing_result.py
+M	docs/SCENARIO_PLATFORM.md
+A	docs/index.md
+A	mkdocs.yml
+A	reporting/__init__.py
+A	reporting/markdown.py
+M	tests/e2e/README.md
+D	tests/e2e/lib/capture_http.py
+M	tests/e2e/lib/check_scenarios.py
+M	tests/e2e/lib/common.sh
+A	tests/e2e/lib/otlp_oracle.sh
+M	tests/e2e/lib/render_issue_summary.py
+M	tests/e2e/lib/upsert_issue.sh
+D	tests/e2e/manifests/blackhole-receiver.yaml
+D	tests/e2e/manifests/log-generator.yaml
+D	tests/e2e/manifests/logfwd-config.yaml
+D	tests/e2e/manifests/logfwd-daemonset.yaml
+D	tests/e2e/run.sh
+M	tests/e2e/scenarios/compose-esql-input-oracle/compose.yaml
+M	tests/e2e/scenarios/compose-memcached/compose.yaml
+M	tests/e2e/scenarios/compose-memcached/memagent.yaml
+M	tests/e2e/scenarios/compose-nginx/compose.yaml
+M	tests/e2e/scenarios/compose-nginx/memagent.yaml
+M	tests/e2e/scenarios/compose-redis/compose.yaml
+M	tests/e2e/scenarios/compose-redis/memagent.yaml
+M	tests/e2e/scenarios/compose-synthetic-burst/compose.yaml
+M	tests/e2e/scenarios/compose-synthetic-multiline/compose.yaml
+M	tests/e2e/scenarios/compose-synthetic-rotation/compose.yaml
+M	tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-daemonset.yaml
+D	tests/e2e/scenarios/otlp-input-oracle/down.sh
+M	tests/e2e/scenarios/otlp-input-oracle/run_workload.sh
+D	tests/e2e/scenarios/otlp-input-oracle/up.sh
+M	tests/e2e/scenarios/otlp-input-oracle/verify.sh
+D	tests/e2e/scenarios/otlp-output-oracle/down.sh
+M	tests/e2e/scenarios/otlp-output-oracle/run_workload.sh
+D	tests/e2e/scenarios/otlp-output-oracle/up.sh
+M	tests/e2e/scenarios/otlp-output-oracle/verify.sh
+```
+
+## GitHub Activity
+
+### recent PRs (state=all, limit=10)
+
+```text
+#280 MERGED feat: add OTLP batch-size matrix (100kb / 4mb) to kind benchmark (strawgate) updated=2026-04-16T04:15:09Z base=main head=feat/otlp-batch-size-matrix https://github.com/strawgate/memagent-e2e/pull/280
+#279 MERGED fix(bench): cap OTLP emitter batch to 4MB, revert 100MB collector limit (strawgate) updated=2026-04-16T03:31:16Z base=main head=fix/otlp-emitter-batch-limit https://github.com/strawgate/memagent-e2e/pull/279
+#278 MERGED fix(bench): raise OTLP collector max_request_body_size to 100MB (strawgate) updated=2026-04-16T03:09:54Z base=main head=fix/otlp-max-body-size https://github.com/strawgate/memagent-e2e/pull/278
+#272 OPEN refactor: streamline and rename test suites (strawgate) updated=2026-04-15T06:07:02Z base=main head=refactor/streamline-and-rename https://github.com/strawgate/memagent-e2e/pull/272
+#269 MERGED feat(bench): collect collector CPU flamegraph as bench artifact (strawgate) updated=2026-04-15T03:18:09Z base=main head=feat/bench-collector-flamegraph https://github.com/strawgate/memagent-e2e/pull/269
+#268 MERGED feat(report): pretty-print EPS, add memory columns, fix snapshot table (strawgate) updated=2026-04-15T02:17:57Z base=main head=fix/report-eps-formatting-and-memory https://github.com/strawgate/memagent-e2e/pull/268
+#265 MERGED fix: accept float seq values in filter_rows_to_emitter_snapshot (strawgate) updated=2026-04-14T14:48:32Z base=main head=fix/otelcol-seq-float-type-check https://github.com/strawgate/memagent-e2e/pull/265
+#260 MERGED fix: raise emitter rollout timeout floor 120s → 300s (strawgate) updated=2026-04-14T06:00:37Z base=main head=fix/emitter-rollout-timeout https://github.com/strawgate/memagent-e2e/pull/260
+#258 MERGED bench(kind): fix collector CPU to exactly 1/2 cores and shorten otelcol drain timeout (strawgate) updated=2026-04-14T05:22:55Z base=main head=fix/kind-cpu-and-otelcol-drain https://github.com/strawgate/memagent-e2e/pull/258
+#254 MERGED docs: add drain-window artifact note to Integrity Alerts section (strawgate) updated=2026-04-13T02:46:54Z base=main head=fix/report-clarity-notes https://github.com/strawgate/memagent-e2e/pull/254
+```
+
+### open issues (limit=15)
+
+```text
+#283 OPEN [PASS] Bench Competitive Benchmarks Report (ladder_and_max) (2 non-gating, 14 passing) (app/github-actions) updated=2026-04-16T04:57:45Z https://github.com/strawgate/memagent-e2e/issues/283
+#275 OPEN [PASS] Bench Compose Nightly EPS Report (all 96 passing) (app/github-actions) updated=2026-04-15T08:17:14Z https://github.com/strawgate/memagent-e2e/issues/275
+#274 OPEN [FAIL] Bench Nightly EPS Report (10/48 failing) (app/github-actions) updated=2026-04-15T08:03:41Z https://github.com/strawgate/memagent-e2e/issues/274
+#273 OPEN [FAIL] E2E Nightly Suite Report (7/9 failing) (app/github-actions) updated=2026-04-15T07:05:54Z https://github.com/strawgate/memagent-e2e/issues/273
+#271 OPEN [PASS] Bench Competitive Benchmarks Report (max) (all 2 passing) (app/github-actions) updated=2026-04-15T03:41:17Z https://github.com/strawgate/memagent-e2e/issues/271
+#251 OPEN [PASS] E2E Smoke Suite Report (all 5 passing) (app/github-actions) updated=2026-04-13T00:03:43Z https://github.com/strawgate/memagent-e2e/issues/251
+#244 OPEN bench: add file-backfill scenario (preseeded source) for max drain throughput (strawgate) updated=2026-04-11T20:54:53Z https://github.com/strawgate/memagent-e2e/issues/244
+#241 OPEN [PASS] Bench Compose Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T20:51:55Z https://github.com/strawgate/memagent-e2e/issues/241
+#237 OPEN bench/kind quick ladder: investigate dup_estimate spikes at 10k target (strawgate) updated=2026-04-11T20:38:53Z https://github.com/strawgate/memagent-e2e/issues/237
+#234 OPEN [PASS] Bench Compose Competitive Benchmarks Report (ladder_and_max) (all 6 passing) (app/github-actions) updated=2026-04-11T20:36:42Z https://github.com/strawgate/memagent-e2e/issues/234
+#226 OPEN [PASS] Bench Compose Competitive Benchmarks Report (max) (all 1 passing) (app/github-actions) updated=2026-04-11T20:19:45Z https://github.com/strawgate/memagent-e2e/issues/226
+#225 OPEN [PASS] Bench Competitive Benchmarks Report (profile) (all 1 passing) (app/github-actions) updated=2026-04-11T20:13:43Z https://github.com/strawgate/memagent-e2e/issues/225
+#174 OPEN [FAIL] Bench Competitive Benchmarks Report (ladder) (1/7 failing) (app/github-actions) updated=2026-04-10T13:22:24Z https://github.com/strawgate/memagent-e2e/issues/174
+#167 OPEN [FAIL] Bench Competitive Benchmarks Report (2/80 failing) (app/github-actions) updated=2026-04-10T06:53:06Z https://github.com/strawgate/memagent-e2e/issues/167
+#166 OPEN [PASS] Bench Compose Competitive Benchmarks Report (all 96 passing) (app/github-actions) updated=2026-04-10T06:51:33Z https://github.com/strawgate/memagent-e2e/issues/166
+```
+
+### recently closed issues (limit=15)
+
+```text
+#282 CLOSED [FAIL] Bench Competitive Benchmarks Report (ladder_and_max) (10/16 failing) (app/github-actions) updated=2026-04-16T04:57:47Z https://github.com/strawgate/memagent-e2e/issues/282
+#281 CLOSED [FAIL] Bench Competitive Benchmarks Report (ladder_and_max) (10/16 failing) (app/github-actions) updated=2026-04-16T04:33:04Z https://github.com/strawgate/memagent-e2e/issues/281
+#277 CLOSED [PASS] Bench Competitive Benchmarks Report (ladder_and_max) (6 non-gating, 26 passing) (app/github-actions) updated=2026-04-16T04:22:51Z https://github.com/strawgate/memagent-e2e/issues/277
+#276 CLOSED [FAIL] Bench Competitive Benchmarks Report (ladder_and_max) (19/32 failing) (app/github-actions) updated=2026-04-15T21:43:46Z https://github.com/strawgate/memagent-e2e/issues/276
+#270 CLOSED [PASS] Bench Competitive Benchmarks Report (max) (all 2 passing) (app/github-actions) updated=2026-04-15T03:41:19Z https://github.com/strawgate/memagent-e2e/issues/270
+#267 CLOSED [PASS] Bench Competitive Benchmarks Report (ladder_and_max) (15 non-gating, 65 passing) (app/github-actions) updated=2026-04-15T20:46:46Z https://github.com/strawgate/memagent-e2e/issues/267
+#266 CLOSED [FAIL] Bench Competitive Benchmarks Report (ladder_and_max) (5/80 failing) (app/github-actions) updated=2026-04-14T17:40:44Z https://github.com/strawgate/memagent-e2e/issues/266
+#264 CLOSED [PASS] Bench Compose Nightly EPS Report (all 96 passing) (app/github-actions) updated=2026-04-15T08:17:16Z https://github.com/strawgate/memagent-e2e/issues/264
+#263 CLOSED [FAIL] Bench Nightly EPS Report (3/48 failing) (app/github-actions) updated=2026-04-15T08:03:43Z https://github.com/strawgate/memagent-e2e/issues/263
+#262 CLOSED [PASS] E2E Nightly Suite Report (all 9 passing) (app/github-actions) updated=2026-04-14T14:48:31Z https://github.com/strawgate/memagent-e2e/issues/262
+#261 CLOSED [FAIL] Bench Competitive Benchmarks Report (ladder_and_max) (5/80 failing) (app/github-actions) updated=2026-04-14T15:11:37Z https://github.com/strawgate/memagent-e2e/issues/261
+#259 CLOSED [FAIL] Bench Competitive Benchmarks Report (ladder_and_max) (5/80 failing) (app/github-actions) updated=2026-04-14T06:00:37Z https://github.com/strawgate/memagent-e2e/issues/259
+#257 CLOSED [PASS] Bench Compose Nightly EPS Report (all 96 passing) (app/github-actions) updated=2026-04-14T08:11:31Z https://github.com/strawgate/memagent-e2e/issues/257
+#256 CLOSED [PASS] Bench Nightly EPS Report (6 non-gating, 42 passing) (app/github-actions) updated=2026-04-14T07:49:27Z https://github.com/strawgate/memagent-e2e/issues/256
+#255 CLOSED [PASS] E2E Nightly Suite Report (all 9 passing) (app/github-actions) updated=2026-04-14T06:34:38Z https://github.com/strawgate/memagent-e2e/issues/255
+```
+
+## Current Directory Files
+
+### directory tree from cwd (depth=3, max=500)
+
+```text
+.codex
+.codex/refresh
+.codex/refresh/refresh-20260414-051616.md
+.codex/refresh/refresh-20260416-054122.md
+.git
+.github
+.github/actions
+.github/actions/checkout-memagent
+.github/actions/collect-e2e-artifacts
+.github/actions/publish-e2e-summary
+.github/actions/setup-compose
+.github/actions/setup-kind
+.github/actions/setup-memagent-build
+.github/workflows
+.github/workflows/_scenario-compose.yml
+.github/workflows/_scenario-kind.yml
+.github/workflows/_scenario-otlp.yml
+.github/workflows/bench-compose-smoke.yml
+.github/workflows/bench-kind-aggregate.yml
+.github/workflows/bench-kind-smoke.yml
+.github/workflows/docs.yml
+.github/workflows/e2e-compose-esql-input-oracle.yml
+.github/workflows/e2e-compose-memcached.yml
+.github/workflows/e2e-compose-nginx.yml
+.github/workflows/e2e-compose-redis.yml
+.github/workflows/e2e-compose-synthetic-burst.yml
+.github/workflows/e2e-compose-synthetic-multiline.yml
+.github/workflows/e2e-compose-synthetic-rotation.yml
+.github/workflows/e2e-kind-cri-smoke.yml
+.github/workflows/e2e-nightly.yml
+.github/workflows/e2e-otlp-input-oracle.yml
+.github/workflows/e2e-otlp-output-oracle.yml
+.github/workflows/e2e-smoke.yml
+.gitignore
+.pytest_cache
+.pytest_cache/.gitignore
+.pytest_cache/CACHEDIR.TAG
+.pytest_cache/README.md
+.pytest_cache/v
+.pytest_cache/v/cache
+README.md
+bench
+bench/compose
+bench/compose/README.md
+bench/compose/run.py
+bench/kind
+bench/kind/.pytest_cache
+bench/kind/README.md
+bench/kind/RESULT_SCHEMA.md
+bench/kind/__pycache__
+bench/kind/lib
+bench/kind/manifests
+bench/kind/render_issue_summary.py
+bench/kind/run.py
+bench/kind/tests
+bench/lib
+bench/lib/__pycache__
+bench/lib/write_missing_result.py
+docs
+docs/SCENARIO_PLATFORM.md
+docs/index.md
+mkdocs.yml
+reporting
+reporting/__init__.py
+reporting/__pycache__
+reporting/__pycache__/__init__.cpython-311.pyc
+reporting/__pycache__/markdown.cpython-311.pyc
+reporting/markdown.py
+tests
+tests/e2e
+tests/e2e/README.md
+tests/e2e/lib
+tests/e2e/run-scenario.sh
+tests/e2e/scenarios
+```
+
+### tracked files in repo (max=500)
+
+```text
+.codex/refresh/refresh-20260414-051616.md
+.github/actions/checkout-memagent/action.yml
+.github/actions/collect-e2e-artifacts/action.yml
+.github/actions/publish-e2e-summary/action.yml
+.github/actions/setup-compose/action.yml
+.github/actions/setup-kind/action.yml
+.github/actions/setup-memagent-build/action.yml
+.github/workflows/_scenario-compose.yml
+.github/workflows/_scenario-kind.yml
+.github/workflows/_scenario-otlp.yml
+.github/workflows/bench-compose-smoke.yml
+.github/workflows/bench-kind-aggregate.yml
+.github/workflows/bench-kind-smoke.yml
+.github/workflows/docs.yml
+.github/workflows/e2e-compose-esql-input-oracle.yml
+.github/workflows/e2e-compose-memcached.yml
+.github/workflows/e2e-compose-nginx.yml
+.github/workflows/e2e-compose-redis.yml
+.github/workflows/e2e-compose-synthetic-burst.yml
+.github/workflows/e2e-compose-synthetic-multiline.yml
+.github/workflows/e2e-compose-synthetic-rotation.yml
+.github/workflows/e2e-kind-cri-smoke.yml
+.github/workflows/e2e-nightly.yml
+.github/workflows/e2e-otlp-input-oracle.yml
+.github/workflows/e2e-otlp-output-oracle.yml
+.github/workflows/e2e-smoke.yml
+.gitignore
+README.md
+bench/compose/README.md
+bench/compose/run.py
+bench/kind/README.md
+bench/kind/RESULT_SCHEMA.md
+bench/kind/lib/analyze.py
+bench/kind/lib/cluster.py
+bench/kind/lib/collectors.py
+bench/kind/lib/diagnostics.py
+bench/kind/lib/kube.py
+bench/kind/lib/measure.py
+bench/kind/lib/profiles.py
+bench/kind/lib/results.py
+bench/kind/manifests/collectors/logfwd-configmap.yaml.tmpl
+bench/kind/manifests/collectors/logfwd-daemonset.yaml.tmpl
+bench/kind/manifests/collectors/logfwd-otlp-configmap.yaml.tmpl
+bench/kind/manifests/collectors/logfwd-otlp-daemonset.yaml.tmpl
+bench/kind/manifests/collectors/otelcol-configmap.yaml.tmpl
+bench/kind/manifests/collectors/otelcol-daemonset.yaml.tmpl
+bench/kind/manifests/collectors/otelcol-otlp-configmap.yaml.tmpl
+bench/kind/manifests/collectors/otelcol-otlp-daemonset.yaml.tmpl
+bench/kind/manifests/collectors/vector-configmap.yaml.tmpl
+bench/kind/manifests/collectors/vector-daemonset.yaml.tmpl
+bench/kind/manifests/common/namespace.yaml
+bench/kind/manifests/common/sink-configmap.yaml.tmpl
+bench/kind/manifests/common/sink-deployment.yaml.tmpl
+bench/kind/manifests/workload/log-emitter-configmap-otlp.yaml.tmpl
+bench/kind/manifests/workload/log-emitter-configmap.yaml.tmpl
+bench/kind/manifests/workload/log-emitter-statefulset.yaml.tmpl
+bench/kind/render_issue_summary.py
+bench/kind/run.py
+bench/kind/tests/test_diagnostics.py
+bench/lib/write_missing_result.py
+docs/SCENARIO_PLATFORM.md
+docs/index.md
+mkdocs.yml
+reporting/__init__.py
+reporting/markdown.py
+tests/e2e/README.md
+tests/e2e/lib/capture_tcp.py
+tests/e2e/lib/check_scenarios.py
+tests/e2e/lib/common.sh
+tests/e2e/lib/oracle.py
+tests/e2e/lib/otlp_oracle.sh
+tests/e2e/lib/render_issue_summary.py
+tests/e2e/lib/source_evidence.py
+tests/e2e/lib/upsert_issue.sh
+tests/e2e/run-scenario.sh
+tests/e2e/scenarios/compose-esql-input-oracle/compose.yaml
+tests/e2e/scenarios/compose-esql-input-oracle/memagent.yaml
+tests/e2e/scenarios/compose-esql-input-oracle/oracle.json
+tests/e2e/scenarios/compose-esql-input-oracle/run_workload.sh
+tests/e2e/scenarios/compose-esql-input-oracle/up.sh
+tests/e2e/scenarios/compose-memcached/compose.yaml
+tests/e2e/scenarios/compose-memcached/memagent.yaml
+tests/e2e/scenarios/compose-memcached/oracle.json
+tests/e2e/scenarios/compose-memcached/run_workload.sh
+tests/e2e/scenarios/compose-memcached/up.sh
+tests/e2e/scenarios/compose-nginx/compose.yaml
+tests/e2e/scenarios/compose-nginx/memagent.yaml
+tests/e2e/scenarios/compose-nginx/nginx.conf
+tests/e2e/scenarios/compose-nginx/oracle.json
+tests/e2e/scenarios/compose-nginx/run_workload.sh
+tests/e2e/scenarios/compose-redis/compose.yaml
+tests/e2e/scenarios/compose-redis/memagent.yaml
+tests/e2e/scenarios/compose-redis/oracle.json
+tests/e2e/scenarios/compose-redis/run_workload.sh
+tests/e2e/scenarios/compose-synthetic-burst/compose.yaml
+tests/e2e/scenarios/compose-synthetic-burst/memagent.yaml
+tests/e2e/scenarios/compose-synthetic-burst/oracle.json
+tests/e2e/scenarios/compose-synthetic-burst/run_workload.sh
+tests/e2e/scenarios/compose-synthetic-multiline/compose.yaml
+tests/e2e/scenarios/compose-synthetic-multiline/memagent.yaml
+tests/e2e/scenarios/compose-synthetic-multiline/oracle.json
+tests/e2e/scenarios/compose-synthetic-multiline/run_workload.sh
+tests/e2e/scenarios/compose-synthetic-rotation/compose.yaml
+tests/e2e/scenarios/compose-synthetic-rotation/memagent.yaml
+tests/e2e/scenarios/compose-synthetic-rotation/oracle.json
+tests/e2e/scenarios/compose-synthetic-rotation/run_workload.sh
+tests/e2e/scenarios/kind-cri-smoke/collect.sh
+tests/e2e/scenarios/kind-cri-smoke/down.sh
+tests/e2e/scenarios/kind-cri-smoke/manifests/capture-receiver.yaml
+tests/e2e/scenarios/kind-cri-smoke/manifests/log-generator.yaml
+tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-config.yaml
+tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-daemonset.yaml
+tests/e2e/scenarios/kind-cri-smoke/oracle.json
+tests/e2e/scenarios/kind-cri-smoke/run_workload.sh
+tests/e2e/scenarios/kind-cri-smoke/up.sh
+tests/e2e/scenarios/kind-cri-smoke/verify.sh
+tests/e2e/scenarios/otlp-input-oracle/run_workload.sh
+tests/e2e/scenarios/otlp-input-oracle/verify.sh
+tests/e2e/scenarios/otlp-output-oracle/run_workload.sh
+tests/e2e/scenarios/otlp-output-oracle/verify.sh
+```
+
+## Suggested Follow-Up
+
+1. Read this snapshot from top to bottom and list assumptions that might now be stale (architecture, contracts, release process, dependencies, roadmap).
+2. Inspect likely-changing files from recent main commits first (design docs, crate contracts, runtime wiring, CI, Cargo.toml).
+3. Cross-check open PRs/issues for behavior changes that have not landed on main yet but affect near-term work.
+4. Produce a short 'what changed / what did not change / what needs deeper confirmation' memo before coding.
+

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,4 +1,4 @@
-name: E2E / nightly suite
+name: E2E Compose Nightly
 
 on:
   schedule:
@@ -101,7 +101,7 @@ jobs:
         run: |
           python3 tests/e2e/lib/render_issue_summary.py \
             --artifacts-root artifacts \
-            --suite-name "E2E Nightly Suite" \
+            --suite-name "E2E Compose Nightly" \
             --suite-key nightly \
             --memagent-ref "${MEMAGENT_REF}" \
             --run-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
@@ -119,7 +119,7 @@ jobs:
       - name: Upsert suite issue
         env:
           GH_TOKEN: ${{ github.token }}
-          ISSUE_TITLE_BASE: E2E Nightly Suite Report
+          ISSUE_TITLE_BASE: E2E Compose Nightly Report
           ISSUE_BODY_FILE: ${{ github.workspace }}/suite-summary.md
           ISSUE_SUMMARY_JSON_FILE: ${{ github.workspace }}/suite-summary.json
           ISSUE_SUITE_KEY: e2e-nightly

--- a/bench/compose/run.py
+++ b/bench/compose/run.py
@@ -957,6 +957,15 @@ def main() -> int:
     if eps_per_sec < 0:
         raise ValueError("eps-per-sec must be >= 0")
 
+    # File output has no natural backpressure (unlike OTLP HTTP), so unlimited
+    # mode (eps_per_sec=0) causes the generator to spin at 100% CPU writing
+    # faster than any collector reads.  Cap at 400k EPS — well above what any
+    # single-core collector can consume, but low enough that the generator's
+    # built-in rate limiter keeps CPU usage reasonable.
+    FILE_INGEST_MAX_EPS = 400_000
+    if args.ingest_mode == "file" and eps_per_sec == 0:
+        eps_per_sec = FILE_INGEST_MAX_EPS
+
     benchmark_id = str(uuid.uuid4())
     timestamp_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -1103,7 +1112,7 @@ def main() -> int:
     measure_completed_at: float | None = None
     capture_file_path = runtime_dir / "capture.ndjson"
     events_file_path = runtime_dir / "events.ndjson"
-    max_throughput_mode = eps_per_sec == 0
+    max_throughput_mode = eps_per_sec == 0 or (args.ingest_mode == "file" and base_profile.eps_per_pod == 0)
 
     try:
         run(compose + ["--profile", adapter.name, "up", "-d", "sink", "capture-reader", adapter.service_name], env=env)

--- a/bench/kind/run.py
+++ b/bench/kind/run.py
@@ -121,7 +121,7 @@ CPU_PROFILES: dict[str, CpuProfile] = {
     "multi": CpuProfile(
         name="multi",
         # 3.0 cores gives the collector exactly 2 cores at all EPS targets:
-        # 3000m - 120m(sink) - 20m(capture) - 5×60m(emitters) = 2560m → capped at 2000m.
+        # 3000m - 120m(sink) - 20m(capture) - emitter budget → collector gets remainder capped at 2000m.
         cluster_cpu_cores=3.0,
         collector_cpu_mcpu_min=1200,
         collector_cpu_mcpu_target=2000,
@@ -296,7 +296,7 @@ def build_resource_plan(
 
     reserved_mcpu = sink_mcpu + capture_reader_mcpu
     if capacity_probe:
-        emitter_total_budget_mcpu = 1000 if cpu_profile.name == "single" else 900
+        emitter_total_budget_mcpu = 1000
         emitter_mcpu = max(cpu_profile.emitter_cpu_mcpu_per_pod, emitter_total_budget_mcpu // emitter_pods)
     else:
         emitter_mcpu = cpu_profile.emitter_cpu_mcpu_per_pod


### PR DESCRIPTION
## Summary

Three fixes for e2e benchmark accuracy and clarity.

### 1. Cap file-ingest generator at 400k EPS (#293)

File output has no natural backpressure (unlike OTLP HTTP), so unlimited mode (`eps_per_sec=0`) causes the generator to spin at ~1.0 CPU. Caps at 400k EPS — well above collector throughput but low enough for the rate limiter to keep CPU reasonable.

### 2. Raise multi emitter CPU budget (#295)

Multi capacity-probe emitter budget was 900m total vs 1000m for single. Now both use 1000m, giving generators enough headroom to saturate a 2-core collector.

### 3. Rename nightly reports (#296)

- Workflow: `E2E / nightly suite` → `E2E Compose Nightly`
- Suite name and issue title updated to match
- Criterion rename in separate PR: strawgate/memagent#2240

Closes #293
Closes #295
Closes #296