### PR TITLE
fix(ci): force install KIND v0.24.0 and fix spurious input

### DIFF
--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -16,12 +16,13 @@ runs:
     - name: Install KIND
       shell: bash
       run: |
-        if ! command -v kind >/dev/null 2>&1; then
-          KIND_VERSION="v0.24.0"
+        KIND_VERSION="v0.24.0"
+        if ! command -v kind >/dev/null 2>&1 || ! kind version | grep -q "${KIND_VERSION}"; then
           curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
         fi
+        kind version
 
     - name: Create or reuse cluster
       shell: bash

--- a/.github/workflows/bench-competitive-k8s.yml
+++ b/.github/workflows/bench-competitive-k8s.yml
@@ -253,7 +253,6 @@ jobs:
       - uses: ./.github/actions/setup-kind
         with:
           cluster-name: ${{ env.CLUSTER_NAME }}
-          results-dir: ${{ env.BENCH_RESULTS_DIR }}
       - if: env.PERSIST_BENCH_DATA == 'true'
         name: Start Octo11y monitor
         id: monitor


### PR DESCRIPTION
## Summary
Fixes two issues found during review:
1. KIND installation was skipped if kind was already in PATH, but the cached version was older and didn't support `--control-plane-cpus` flag
2. Workflow was passing `results-dir` input to setup-kind action which doesn't have this input

## Changes
- `.github/actions/setup-kind/action.yml`: Force install KIND v0.24.0 and verify version
- `.github/workflows/bench-competitive-k8s.yml`: Remove spurious `results-dir` input from setup-kind call