### PR TITLE
fix(ci): shorten cluster name to avoid hostname length limit

### DIFF
--- a/.github/workflows/bench-competitive-k8s.yml
+++ b/.github/workflows/bench-competitive-k8s.yml
@@ -228,7 +228,7 @@ jobs:
       MEMAGENT_REPO_ROOT: ${{ github.workspace }}/memagent
       BENCH_PROFILE: ${{ needs.plan.outputs.bench_profile }}
       BENCH_RESULTS_DIR: ${{ github.workspace }}/bench/kind/results/${{ needs.plan.outputs.bench_profile }}/${{ matrix.ingest_mode }}/${{ matrix.workload.label }}/${{ matrix.cpu_profile }}/${{ matrix.collector }}
-      CLUSTER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.ingest_mode }}-${{ matrix.cpu_profile }}-${{ matrix.collector }}-${{ matrix.workload.label }}
+      CLUSTER_NAME: b-${{ github.run_id }}-${{ matrix.ingest_mode }}-${{ matrix.cpu_profile }}-${{ matrix.collector }}
       BENCH_COLLECTOR: ${{ matrix.collector }}
       BENCH_INGEST_MODE: ${{ matrix.ingest_mode }}
       BENCH_CPU_PROFILE: ${{ matrix.cpu_profile }}


### PR DESCRIPTION
## Summary
- **Root cause**: Cluster names were too long (53+ chars), causing `sethostname: invalid argument` errors when kind appends `-control-plane` to create the node hostname, exceeding the kernel's 64-character limit.
- **Fix**: Removed `run_attempt` and `workload_label` from CLUSTER_NAME.

**Before**: `b-{run_id}-{run_attempt}-{ingest}-{cpu}-{collector}-{label}` (~53 chars)
**After**: `b-{run_id}-{ingest}-{cpu}-{collector}` (~39 chars)

The rename from `logfwd` to `fastforward` made the name longer, pushing it over the limit.

## Testing
- Verified the new cluster name length fits well under the 64-char limit