### PR TITLE
fix(k8s): remove duplicate 'ff' arg in container commands

### DIFF
--- a/bench/kind/manifests/collectors/fastforward-daemonset.yaml.tmpl
+++ b/bench/kind/manifests/collectors/fastforward-daemonset.yaml.tmpl
@@ -24,7 +24,7 @@ spec:
         - name: fastforward
           image: ${MEMAGENT_IMAGE}
           imagePullPolicy: IfNotPresent
-          args: ["ff", "run", "--config", "/etc/fastforward/config.yaml"]
+          args: ["run", "--config", "/etc/fastforward/config.yaml"]
           resources:
             requests:
               cpu: ${COLLECTOR_CPU_REQUEST}

--- a/bench/kind/manifests/collectors/fastforward-otlp-daemonset.yaml.tmpl
+++ b/bench/kind/manifests/collectors/fastforward-otlp-daemonset.yaml.tmpl
@@ -24,7 +24,7 @@ spec:
         - name: fastforward
           image: ${MEMAGENT_IMAGE}
           imagePullPolicy: IfNotPresent
-          args: ["ff", "run", "--config", "/etc/fastforward/config.yaml"]
+          args: ["run", "--config", "/etc/fastforward/config.yaml"]
           resources:
             requests:
               cpu: ${COLLECTOR_CPU_REQUEST}

--- a/bench/kind/manifests/common/sink-deployment.yaml.tmpl
+++ b/bench/kind/manifests/common/sink-deployment.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
         - name: fastforward
           image: ${MEMAGENT_IMAGE}
           imagePullPolicy: IfNotPresent
-          args: ["ff", "run", "--config", "/etc/fastforward/config.yaml"]
+          args: ["run", "--config", "/etc/fastforward/config.yaml"]
           resources:
             requests:
               cpu: ${SINK_CPU_REQUEST}

--- a/bench/kind/manifests/workload/log-emitter-statefulset.yaml.tmpl
+++ b/bench/kind/manifests/workload/log-emitter-statefulset.yaml.tmpl
@@ -33,7 +33,7 @@ spec:
         - name: emitter
           image: ${MEMAGENT_IMAGE}
           imagePullPolicy: IfNotPresent
-          args: ["ff", "run", "--config", "/etc/fastforward/config.yaml"]
+          args: ["run", "--config", "/etc/fastforward/config.yaml"]
           resources:
             requests:
               cpu: ${EMITTER_CPU_REQUEST}


### PR DESCRIPTION
## Summary
- Fix duplicate 'ff' argument in Kubernetes container commands
- The Dockerfile.e2e ENTRYPOINT is `["ff"]`, but args also included `"ff"`, resulting in `ff ff run ...` which fails

## Files Changed
- bench/kind/manifests/common/sink-deployment.yaml.tmpl
- bench/kind/manifests/collectors/fastforward-daemonset.yaml.tmpl
- bench/kind/manifests/collectors/fastforward-otlp-daemonset.yaml.tmpl
- bench/kind/manifests/workload/log-emitter-statefulset.yaml.tmpl

## Testing
- CI will run kind-bench-smoke to verify the fix